### PR TITLE
Add interactive polling components with basic and enhanced examples

### DIFF
--- a/src/crm/CrmDashboard.tsx
+++ b/src/crm/CrmDashboard.tsx
@@ -69,6 +69,7 @@ export default function CrmDashboard() {
               <Route path="contacts" element={<Contacts />} />
               <Route path="tasks" element={<Tasks />} />
               <Route path="reports" element={<Reports />} />
+              <Route path="polls" element={<Polls />} />
               <Route path="settings" element={<Settings />} />
             </Routes>
             <Outlet />

--- a/src/crm/CrmDashboard.tsx
+++ b/src/crm/CrmDashboard.tsx
@@ -17,6 +17,7 @@ import Deals from "./pages/Deals";
 import Contacts from "./pages/Contacts";
 import Tasks from "./pages/Tasks";
 import Reports from "./pages/Reports";
+import Polls from "./pages/Polls";
 import Settings from "./pages/Settings";
 import AppTheme from "../shared-theme/AppTheme";
 import {

--- a/src/crm/components/BasicPoll.tsx
+++ b/src/crm/components/BasicPoll.tsx
@@ -1,0 +1,143 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import LinearProgress from "@mui/material/LinearProgress";
+import RadioGroup from "@mui/material/RadioGroup";
+import Radio from "@mui/material/Radio";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormControl from "@mui/material/FormControl";
+import Divider from "@mui/material/Divider";
+import Stack from "@mui/material/Stack";
+
+interface PollOption {
+  id: string;
+  text: string;
+  votes: number;
+}
+
+interface BasicPollProps {
+  question: string;
+  options: PollOption[];
+  onVote?: (optionId: string) => void;
+}
+
+export default function BasicPoll({
+  question,
+  options,
+  onVote
+}: BasicPollProps) {
+  const [selectedOption, setSelectedOption] = React.useState<string>("");
+  const [hasVoted, setHasVoted] = React.useState(false);
+
+  const totalVotes = options.reduce((sum, option) => sum + option.votes, 0);
+
+  const handleSelectionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedOption(event.target.value);
+  };
+
+  const handleVote = () => {
+    if (selectedOption && !hasVoted) {
+      setHasVoted(true);
+      onVote?.(selectedOption);
+    }
+  };
+
+  const getPercentage = (votes: number) => {
+    return totalVotes > 0 ? (votes / totalVotes) * 100 : 0;
+  };
+
+  return (
+    <Card sx={{ maxWidth: 600, mx: "auto", mb: 3 }}>
+      <CardContent>
+        <Typography variant="h5" component="h2" gutterBottom>
+          {question}
+        </Typography>
+        
+        {!hasVoted ? (
+          <Box>
+            <FormControl component="fieldset" sx={{ width: "100%" }}>
+              <RadioGroup
+                value={selectedOption}
+                onChange={handleSelectionChange}
+              >
+                {options.map((option) => (
+                  <FormControlLabel
+                    key={option.id}
+                    value={option.id}
+                    control={<Radio />}
+                    label={option.text}
+                    sx={{ mb: 1 }}
+                  />
+                ))}
+              </RadioGroup>
+            </FormControl>
+            
+            <Box sx={{ mt: 2 }}>
+              <Button
+                variant="contained"
+                onClick={handleVote}
+                disabled={!selectedOption}
+                size="large"
+              >
+                Submit Vote
+              </Button>
+            </Box>
+          </Box>
+        ) : (
+          <Box>
+            <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
+              Poll Results
+            </Typography>
+            <Divider sx={{ mb: 2 }} />
+            
+            <Stack spacing={2}>
+              {options.map((option) => {
+                const percentage = getPercentage(option.votes);
+                const isSelected = option.id === selectedOption;
+                
+                return (
+                  <Box key={option.id}>
+                    <Box sx={{ display: "flex", justifyContent: "space-between", mb: 0.5 }}>
+                      <Typography 
+                        variant="body1" 
+                        sx={{ 
+                          fontWeight: isSelected ? 600 : 400,
+                          color: isSelected ? "primary.main" : "text.primary"
+                        }}
+                      >
+                        {option.text} {isSelected && "✓"}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {option.votes} votes ({percentage.toFixed(1)}%)
+                      </Typography>
+                    </Box>
+                    <LinearProgress
+                      variant="determinate"
+                      value={percentage}
+                      sx={{
+                        height: 8,
+                        borderRadius: 4,
+                        backgroundColor: "grey.200",
+                        "& .MuiLinearProgress-bar": {
+                          backgroundColor: isSelected ? "primary.main" : "secondary.main",
+                          borderRadius: 4,
+                        },
+                      }}
+                    />
+                  </Box>
+                );
+              })}
+            </Stack>
+            
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+              Total votes: {totalVotes}
+            </Typography>
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/crm/components/CrmMenuContent.tsx
+++ b/src/crm/components/CrmMenuContent.tsx
@@ -25,6 +25,7 @@ const mainListItems = [
   { text: "Contacts", icon: <ContactsRoundedIcon />, path: "/contacts" },
   { text: "Tasks", icon: <AssignmentRoundedIcon />, path: "/tasks" },
   { text: "Reports", icon: <AssessmentRoundedIcon />, path: "/reports" },
+  { text: "Polls", icon: <PollIcon />, path: "/polls" },
 ];
 
 const secondaryListItems = [

--- a/src/crm/components/CrmMenuContent.tsx
+++ b/src/crm/components/CrmMenuContent.tsx
@@ -16,6 +16,7 @@ import AssignmentRoundedIcon from "@mui/icons-material/AssignmentRounded";
 import AssessmentRoundedIcon from "@mui/icons-material/AssessmentRounded";
 import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
 import HelpOutlineRoundedIcon from "@mui/icons-material/HelpOutlineRounded";
+import CustomPollIcon from "./CustomPollIcon";
 
 const mainListItems = [
   { text: "Dashboard", icon: <DashboardRoundedIcon />, path: "/" },

--- a/src/crm/components/CrmMenuContent.tsx
+++ b/src/crm/components/CrmMenuContent.tsx
@@ -14,7 +14,6 @@ import BusinessCenterRoundedIcon from "@mui/icons-material/BusinessCenterRounded
 import ContactsRoundedIcon from "@mui/icons-material/ContactsRounded";
 import AssignmentRoundedIcon from "@mui/icons-material/AssignmentRounded";
 import AssessmentRoundedIcon from "@mui/icons-material/AssessmentRounded";
-import PollIcon from "@mui/icons-material/Poll";
 import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
 import HelpOutlineRoundedIcon from "@mui/icons-material/HelpOutlineRounded";
 

--- a/src/crm/components/CrmMenuContent.tsx
+++ b/src/crm/components/CrmMenuContent.tsx
@@ -25,7 +25,7 @@ const mainListItems = [
   { text: "Contacts", icon: <ContactsRoundedIcon />, path: "/contacts" },
   { text: "Tasks", icon: <AssignmentRoundedIcon />, path: "/tasks" },
   { text: "Reports", icon: <AssessmentRoundedIcon />, path: "/reports" },
-  { text: "Polls", icon: <PollIcon />, path: "/polls" },
+  { text: "Polls", icon: <CustomPollIcon />, path: "/polls" },
 ];
 
 const secondaryListItems = [

--- a/src/crm/components/CrmMenuContent.tsx
+++ b/src/crm/components/CrmMenuContent.tsx
@@ -14,6 +14,7 @@ import BusinessCenterRoundedIcon from "@mui/icons-material/BusinessCenterRounded
 import ContactsRoundedIcon from "@mui/icons-material/ContactsRounded";
 import AssignmentRoundedIcon from "@mui/icons-material/AssignmentRounded";
 import AssessmentRoundedIcon from "@mui/icons-material/AssessmentRounded";
+import PollIcon from "@mui/icons-material/Poll";
 import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
 import HelpOutlineRoundedIcon from "@mui/icons-material/HelpOutlineRounded";
 

--- a/src/crm/components/CrmSideMenuMobile.tsx
+++ b/src/crm/components/CrmSideMenuMobile.tsx
@@ -15,6 +15,7 @@ import BusinessCenterRoundedIcon from "@mui/icons-material/BusinessCenterRounded
 import ContactsRoundedIcon from "@mui/icons-material/ContactsRounded";
 import AssignmentRoundedIcon from "@mui/icons-material/AssignmentRounded";
 import AssessmentRoundedIcon from "@mui/icons-material/AssessmentRounded";
+import PollIcon from "@mui/icons-material/Poll";
 import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
 import HelpOutlineRoundedIcon from "@mui/icons-material/HelpOutlineRounded";
 import { CrmLogo } from "./CrmAppNavbar";

--- a/src/crm/components/CrmSideMenuMobile.tsx
+++ b/src/crm/components/CrmSideMenuMobile.tsx
@@ -18,6 +18,7 @@ import AssessmentRoundedIcon from "@mui/icons-material/AssessmentRounded";
 import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
 import HelpOutlineRoundedIcon from "@mui/icons-material/HelpOutlineRounded";
 import { CrmLogo } from "./CrmAppNavbar";
+import CustomPollIcon from "./CustomPollIcon";
 
 const mainListItems = [
   { text: "Dashboard", icon: <DashboardRoundedIcon />, path: "/" },

--- a/src/crm/components/CrmSideMenuMobile.tsx
+++ b/src/crm/components/CrmSideMenuMobile.tsx
@@ -27,6 +27,7 @@ const mainListItems = [
   { text: "Contacts", icon: <ContactsRoundedIcon />, path: "/contacts" },
   { text: "Tasks", icon: <AssignmentRoundedIcon />, path: "/tasks" },
   { text: "Reports", icon: <AssessmentRoundedIcon />, path: "/reports" },
+  { text: "Polls", icon: <PollIcon />, path: "/polls" },
 ];
 
 const secondaryListItems = [

--- a/src/crm/components/CrmSideMenuMobile.tsx
+++ b/src/crm/components/CrmSideMenuMobile.tsx
@@ -27,7 +27,7 @@ const mainListItems = [
   { text: "Contacts", icon: <ContactsRoundedIcon />, path: "/contacts" },
   { text: "Tasks", icon: <AssignmentRoundedIcon />, path: "/tasks" },
   { text: "Reports", icon: <AssessmentRoundedIcon />, path: "/reports" },
-  { text: "Polls", icon: <PollIcon />, path: "/polls" },
+  { text: "Polls", icon: <CustomPollIcon />, path: "/polls" },
 ];
 
 const secondaryListItems = [

--- a/src/crm/components/CrmSideMenuMobile.tsx
+++ b/src/crm/components/CrmSideMenuMobile.tsx
@@ -15,7 +15,6 @@ import BusinessCenterRoundedIcon from "@mui/icons-material/BusinessCenterRounded
 import ContactsRoundedIcon from "@mui/icons-material/ContactsRounded";
 import AssignmentRoundedIcon from "@mui/icons-material/AssignmentRounded";
 import AssessmentRoundedIcon from "@mui/icons-material/AssessmentRounded";
-import PollIcon from "@mui/icons-material/Poll";
 import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
 import HelpOutlineRoundedIcon from "@mui/icons-material/HelpOutlineRounded";
 import { CrmLogo } from "./CrmAppNavbar";

--- a/src/crm/components/CustomPollIcon.tsx
+++ b/src/crm/components/CustomPollIcon.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import SvgIcon, { SvgIconProps } from "@mui/material/SvgIcon";
+
+export default function CustomPollIcon(props: SvgIconProps) {
+  return (
+    <SvgIcon {...props} viewBox="0 0 24 24">
+      {/* Poll chart bars */}
+      <rect x="3" y="15" width="3" height="6" rx="1" fill="currentColor" />
+      <rect x="7.5" y="11" width="3" height="10" rx="1" fill="currentColor" />
+      <rect x="12" y="8" width="3" height="13" rx="1" fill="currentColor" />
+      <rect x="16.5" y="13" width="3" height="8" rx="1" fill="currentColor" />
+      
+      {/* Vote/checkbox symbols */}
+      <circle cx="4.5" cy="4" r="1.5" fill="currentColor" opacity="0.7" />
+      <circle cx="9" cy="4" r="1.5" fill="currentColor" opacity="0.7" />
+      <circle cx="13.5" cy="4" r="1.5" fill="currentColor" opacity="0.7" />
+      <circle cx="18" cy="4" r="1.5" fill="currentColor" opacity="0.7" />
+      
+      {/* Check marks */}
+      <path d="M3.5 4 L4 4.5 L5.5 3" stroke="white" strokeWidth="0.5" fill="none" />
+      <path d="M12.5 4 L13 4.5 L14.5 3" stroke="white" strokeWidth="0.5" fill="none" />
+    </SvgIcon>
+  );
+}

--- a/src/crm/components/WildPoll.tsx
+++ b/src/crm/components/WildPoll.tsx
@@ -396,10 +396,30 @@ export default function WildPoll({
           </Box>
         ) : (
           <Box>
-            <Box sx={{ display: "flex", alignItems: "center", mb: 3 }}>
-              <TrendingUpIcon sx={{ color: "success.main", mr: 1 }} />
-              <Typography variant="h5" sx={{ fontWeight: 600, color: "success.main" }}>
-                Live Results
+            <Box sx={{
+              display: "flex",
+              alignItems: "center",
+              mb: 4,
+              p: 2,
+              background: "linear-gradient(135deg, rgba(50,205,50,0.3) 0%, rgba(255,255,0,0.3) 100%)",
+              borderRadius: 3,
+              border: "3px solid #32CD32"
+            }}>
+              <TrendingUpIcon sx={{
+                color: "#FFD700",
+                mr: 2,
+                fontSize: 35,
+                filter: "drop-shadow(2px 2px 4px rgba(50,205,50,0.5))"
+              }} />
+              <Typography variant="h4" sx={{
+                fontWeight: 800,
+                background: "linear-gradient(135deg, #FFD700 0%, #32CD32 100%)",
+                backgroundClip: "text",
+                WebkitBackgroundClip: "text",
+                WebkitTextFillColor: "transparent",
+                textShadow: "2px 2px 4px rgba(255,215,0,0.3)"
+              }}>
+                🎉 EXPLOSIVE LIVE RESULTS! 🎉
               </Typography>
             </Box>
             

--- a/src/crm/components/WildPoll.tsx
+++ b/src/crm/components/WildPoll.tsx
@@ -1,0 +1,336 @@
+import * as React from "react";
+import { styled } from "@mui/material/styles";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
+import Divider from "@mui/material/Divider";
+import Stack from "@mui/material/Stack";
+import Avatar from "@mui/material/Avatar";
+import Badge from "@mui/material/Badge";
+import { keyframes } from "@mui/material/styles";
+import PollIcon from "@mui/icons-material/Poll";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import TrendingUpIcon from "@mui/icons-material/TrendingUp";
+import GroupIcon from "@mui/icons-material/Group";
+import TimerIcon from "@mui/icons-material/Timer";
+
+// Animations
+const pulseAnimation = keyframes`
+  0% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+  100% { transform: scale(1); }
+`;
+
+const slideInAnimation = keyframes`
+  0% { transform: translateX(-20px); opacity: 0; }
+  100% { transform: translateX(0); opacity: 1; }
+`;
+
+const progressFillAnimation = keyframes`
+  0% { width: 0%; }
+  100% { width: var(--target-width); }
+`;
+
+// Styled components
+const AnimatedCard = styled(Card)(({ theme }) => ({
+  background: `linear-gradient(135deg, ${theme.palette.primary.main}15 0%, ${theme.palette.secondary.main}15 100%)`,
+  border: `2px solid ${theme.palette.primary.main}30`,
+  borderRadius: 16,
+  boxShadow: `0 8px 32px ${theme.palette.primary.main}20`,
+  transition: "all 0.3s ease-in-out",
+  "&:hover": {
+    transform: "translateY(-4px)",
+    boxShadow: `0 12px 40px ${theme.palette.primary.main}30`,
+  },
+}));
+
+const OptionButton = styled(Button)<{ selected?: boolean }>(({ theme, selected }) => ({
+  justifyContent: "flex-start",
+  padding: "16px 20px",
+  marginBottom: 12,
+  borderRadius: 12,
+  textTransform: "none",
+  fontSize: "1rem",
+  fontWeight: 500,
+  border: `2px solid ${selected ? theme.palette.primary.main : theme.palette.divider}`,
+  backgroundColor: selected ? `${theme.palette.primary.main}15` : "transparent",
+  color: selected ? theme.palette.primary.main : theme.palette.text.primary,
+  transition: "all 0.3s ease",
+  "&:hover": {
+    backgroundColor: `${theme.palette.primary.main}10`,
+    borderColor: theme.palette.primary.main,
+    animation: `${pulseAnimation} 0.6s ease-in-out`,
+  },
+}));
+
+const ResultBar = styled(Box)<{ percentage: number; isWinner?: boolean; delay?: number }>(
+  ({ theme, percentage, isWinner, delay = 0 }) => ({
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: theme.palette.grey[200],
+    position: "relative",
+    overflow: "hidden",
+    marginBottom: 8,
+    border: isWinner ? `2px solid ${theme.palette.success.main}` : "none",
+    "&::after": {
+      content: '""',
+      position: "absolute",
+      top: 0,
+      left: 0,
+      height: "100%",
+      width: `${percentage}%`,
+      background: isWinner
+        ? `linear-gradient(90deg, ${theme.palette.success.main}, ${theme.palette.success.light})`
+        : `linear-gradient(90deg, ${theme.palette.primary.main}, ${theme.palette.secondary.main})`,
+      borderRadius: "inherit",
+      animation: `${progressFillAnimation} 2s ease-out ${delay}s both`,
+      "--target-width": `${percentage}%`,
+    },
+  })
+);
+
+const ResultLabel = styled(Box)(({ theme }) => ({
+  position: "absolute",
+  top: "50%",
+  left: 16,
+  transform: "translateY(-50%)",
+  zIndex: 1,
+  color: theme.palette.text.primary,
+  fontWeight: 600,
+  fontSize: "0.9rem",
+  animation: `${slideInAnimation} 0.8s ease-out 1s both`,
+}));
+
+interface PollOption {
+  id: string;
+  text: string;
+  votes: number;
+  emoji?: string;
+  description?: string;
+}
+
+interface WildPollProps {
+  question: string;
+  options: PollOption[];
+  totalParticipants?: number;
+  timeRemaining?: string;
+  onVote?: (optionId: string) => void;
+}
+
+export default function WildPoll({
+  question,
+  options,
+  totalParticipants = 0,
+  timeRemaining,
+  onVote
+}: WildPollProps) {
+  const [selectedOption, setSelectedOption] = React.useState<string>("");
+  const [hasVoted, setHasVoted] = React.useState(false);
+  const [showResults, setShowResults] = React.useState(false);
+
+  const totalVotes = options.reduce((sum, option) => sum + option.votes, 0);
+  const winningOption = options.reduce((prev, current) => 
+    current.votes > prev.votes ? current : prev
+  );
+
+  const handleVote = () => {
+    if (selectedOption && !hasVoted) {
+      setHasVoted(true);
+      // Delayed animation for results
+      setTimeout(() => setShowResults(true), 500);
+      onVote?.(selectedOption);
+    }
+  };
+
+  const getPercentage = (votes: number) => {
+    return totalVotes > 0 ? (votes / totalVotes) * 100 : 0;
+  };
+
+  return (
+    <AnimatedCard sx={{ maxWidth: 700, mx: "auto", mb: 3 }}>
+      <CardContent sx={{ p: 3 }}>
+        {/* Header */}
+        <Box sx={{ display: "flex", alignItems: "center", mb: 3 }}>
+          <Badge badgeContent={<PollIcon sx={{ fontSize: 16 }} />} color="primary">
+            <Avatar sx={{ bgcolor: "primary.main", mr: 2 }}>
+              <PollIcon />
+            </Avatar>
+          </Badge>
+          <Box sx={{ flex: 1 }}>
+            <Typography variant="h4" component="h2" sx={{ fontWeight: 700, mb: 0.5 }}>
+              {question}
+            </Typography>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <Chip 
+                icon={<GroupIcon />} 
+                label={`${totalParticipants} participants`} 
+                size="small" 
+                variant="outlined"
+              />
+              {timeRemaining && (
+                <Chip 
+                  icon={<TimerIcon />} 
+                  label={timeRemaining} 
+                  size="small" 
+                  color="warning"
+                  variant="outlined"
+                />
+              )}
+            </Stack>
+          </Box>
+        </Box>
+
+        <Divider sx={{ mb: 3, borderWidth: 2, borderColor: "primary.main" }} />
+        
+        {!hasVoted ? (
+          <Box>
+            <Typography variant="h6" gutterBottom sx={{ mb: 3, color: "text.secondary" }}>
+              Choose your answer:
+            </Typography>
+            
+            <Stack spacing={1}>
+              {options.map((option, index) => (
+                <OptionButton
+                  key={option.id}
+                  fullWidth
+                  selected={selectedOption === option.id}
+                  onClick={() => setSelectedOption(option.id)}
+                  sx={{
+                    animationDelay: `${index * 0.1}s`,
+                    animation: `${slideInAnimation} 0.6s ease-out both`,
+                  }}
+                >
+                  <Box sx={{ display: "flex", alignItems: "center", flex: 1 }}>
+                    {option.emoji && (
+                      <Typography sx={{ fontSize: "1.5rem", mr: 2 }}>
+                        {option.emoji}
+                      </Typography>
+                    )}
+                    <Box sx={{ textAlign: "left" }}>
+                      <Typography variant="body1" sx={{ fontWeight: 600 }}>
+                        {option.text}
+                      </Typography>
+                      {option.description && (
+                        <Typography variant="body2" color="text.secondary">
+                          {option.description}
+                        </Typography>
+                      )}
+                    </Box>
+                  </Box>
+                  {selectedOption === option.id && (
+                    <CheckCircleIcon sx={{ color: "primary.main", ml: 2 }} />
+                  )}
+                </OptionButton>
+              ))}
+            </Stack>
+            
+            <Box sx={{ mt: 4, textAlign: "center" }}>
+              <Button
+                variant="contained"
+                onClick={handleVote}
+                disabled={!selectedOption}
+                size="large"
+                sx={{
+                  px: 4,
+                  py: 1.5,
+                  fontSize: "1.1rem",
+                  fontWeight: 600,
+                  borderRadius: 3,
+                  textTransform: "none",
+                  background: "linear-gradient(45deg, #2196F3 30%, #21CBF3 90%)",
+                  boxShadow: "0 4px 20px rgba(33, 150, 243, 0.3)",
+                  "&:hover": {
+                    transform: "translateY(-2px)",
+                    boxShadow: "0 6px 25px rgba(33, 150, 243, 0.4)",
+                  },
+                }}
+              >
+                Cast Your Vote 🗳️
+              </Button>
+            </Box>
+          </Box>
+        ) : (
+          <Box>
+            <Box sx={{ display: "flex", alignItems: "center", mb: 3 }}>
+              <TrendingUpIcon sx={{ color: "success.main", mr: 1 }} />
+              <Typography variant="h5" sx={{ fontWeight: 600, color: "success.main" }}>
+                Live Results
+              </Typography>
+            </Box>
+            
+            {showResults && (
+              <Stack spacing={2}>
+                {options.map((option, index) => {
+                  const percentage = getPercentage(option.votes);
+                  const isSelected = option.id === selectedOption;
+                  const isWinner = option.id === winningOption.id && totalVotes > 0;
+                  
+                  return (
+                    <Box key={option.id} sx={{ position: "relative" }}>
+                      <Box sx={{ display: "flex", justifyContent: "space-between", mb: 1, alignItems: "center" }}>
+                        <Box sx={{ display: "flex", alignItems: "center" }}>
+                          {option.emoji && (
+                            <Typography sx={{ fontSize: "1.2rem", mr: 1 }}>
+                              {option.emoji}
+                            </Typography>
+                          )}
+                          <Typography 
+                            variant="body1" 
+                            sx={{ 
+                              fontWeight: isSelected || isWinner ? 700 : 500,
+                              color: isWinner ? "success.main" : isSelected ? "primary.main" : "text.primary"
+                            }}
+                          >
+                            {option.text}
+                            {isSelected && " ✓"}
+                            {isWinner && totalVotes > 0 && " 🏆"}
+                          </Typography>
+                        </Box>
+                        <Chip
+                          label={`${option.votes} votes • ${percentage.toFixed(1)}%`}
+                          size="small"
+                          color={isWinner ? "success" : isSelected ? "primary" : "default"}
+                          variant={isWinner || isSelected ? "filled" : "outlined"}
+                        />
+                      </Box>
+                      <ResultBar 
+                        percentage={percentage} 
+                        isWinner={isWinner}
+                        delay={index * 0.2}
+                      >
+                        <ResultLabel>
+                          {percentage > 15 && `${percentage.toFixed(1)}%`}
+                        </ResultLabel>
+                      </ResultBar>
+                    </Box>
+                  );
+                })}
+              </Stack>
+            )}
+            
+            <Box sx={{ 
+              mt: 3, 
+              p: 2, 
+              bgcolor: "background.paper", 
+              borderRadius: 2,
+              border: "1px solid",
+              borderColor: "divider"
+            }}>
+              <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Typography variant="body1" sx={{ fontWeight: 600 }}>
+                  Total Votes: {totalVotes}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Thank you for participating! 🎉
+                </Typography>
+              </Stack>
+            </Box>
+          </Box>
+        )}
+      </CardContent>
+    </AnimatedCard>
+  );
+}

--- a/src/crm/components/WildPoll.tsx
+++ b/src/crm/components/WildPoll.tsx
@@ -63,20 +63,47 @@ const AnimatedCard = styled(Card)(({ theme }) => ({
 
 const OptionButton = styled(Button)<{ selected?: boolean }>(({ theme, selected }) => ({
   justifyContent: "flex-start",
-  padding: "16px 20px",
-  marginBottom: 12,
-  borderRadius: 12,
+  padding: "20px 24px",
+  marginBottom: 16,
+  borderRadius: 20,
   textTransform: "none",
-  fontSize: "1rem",
-  fontWeight: 500,
-  border: `2px solid ${selected ? theme.palette.primary.main : theme.palette.divider}`,
-  backgroundColor: selected ? `${theme.palette.primary.main}15` : "transparent",
-  color: selected ? theme.palette.primary.main : theme.palette.text.primary,
-  transition: "all 0.3s ease",
+  fontSize: "1.1rem",
+  fontWeight: 600,
+  border: selected
+    ? `3px solid #FFD700`
+    : `3px solid #32CD32`,
+  background: selected
+    ? `linear-gradient(135deg, #FFFF00 0%, #FFD700 50%, #FFA500 100%)`
+    : `linear-gradient(135deg, #90EE90 0%, #32CD32 50%, #228B22 100%)`,
+  color: selected ? "#2E7D32" : "#1B5E20",
+  boxShadow: selected
+    ? `0 8px 25px rgba(255, 215, 0, 0.5)`
+    : `0 6px 20px rgba(50, 205, 50, 0.4)`,
+  transition: "all 0.4s cubic-bezier(0.4, 0, 0.2, 1)",
+  position: "relative",
+  overflow: "hidden",
+  "&:before": {
+    content: '""',
+    position: "absolute",
+    top: 0,
+    left: "-100%",
+    width: "100%",
+    height: "100%",
+    background: `linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent)`,
+    transition: "left 0.6s",
+  },
   "&:hover": {
-    backgroundColor: `${theme.palette.primary.main}10`,
-    borderColor: theme.palette.primary.main,
-    animation: `${pulseAnimation} 0.6s ease-in-out`,
+    transform: "translateY(-4px) scale(1.02)",
+    background: selected
+      ? `linear-gradient(135deg, #FFFF33 0%, #FFD700 50%, #FF8C00 100%)`
+      : `linear-gradient(135deg, #98FB98 0%, #00FF00 50%, #00FF7F 100%)`,
+    boxShadow: selected
+      ? `0 12px 35px rgba(255, 215, 0, 0.7)`
+      : `0 10px 30px rgba(50, 205, 50, 0.6)`,
+    animation: `${pulseAnimation} 0.8s ease-in-out infinite`,
+    "&:before": {
+      left: "100%",
+    },
   },
 }));
 

--- a/src/crm/components/WildPoll.tsx
+++ b/src/crm/components/WildPoll.tsx
@@ -109,13 +109,26 @@ const OptionButton = styled(Button)<{ selected?: boolean }>(({ theme, selected }
 
 const ResultBar = styled(Box)<{ percentage: number; isWinner?: boolean; delay?: number }>(
   ({ theme, percentage, isWinner, delay = 0 }) => ({
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: theme.palette.grey[200],
+    height: 50,
+    borderRadius: 25,
+    backgroundColor: "#E8F5E8",
     position: "relative",
     overflow: "hidden",
-    marginBottom: 8,
-    border: isWinner ? `2px solid ${theme.palette.success.main}` : "none",
+    marginBottom: 12,
+    border: isWinner ? `4px solid #FFD700` : `2px solid #90EE90`,
+    boxShadow: isWinner
+      ? `0 6px 20px rgba(255, 215, 0, 0.4)`
+      : `0 4px 15px rgba(50, 205, 50, 0.3)`,
+    "&::before": {
+      content: '""',
+      position: "absolute",
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      background: `repeating-linear-gradient(45deg, transparent, transparent 10px, rgba(255,255,255,0.1) 10px, rgba(255,255,255,0.1) 20px)`,
+      zIndex: 2,
+    },
     "&::after": {
       content: '""',
       position: "absolute",
@@ -124,11 +137,15 @@ const ResultBar = styled(Box)<{ percentage: number; isWinner?: boolean; delay?: 
       height: "100%",
       width: `${percentage}%`,
       background: isWinner
-        ? `linear-gradient(90deg, ${theme.palette.success.main}, ${theme.palette.success.light})`
-        : `linear-gradient(90deg, ${theme.palette.primary.main}, ${theme.palette.secondary.main})`,
+        ? `linear-gradient(90deg, #FFFF00 0%, #FFD700 30%, #FFA500 60%, #FF6347 100%)`
+        : `linear-gradient(90deg, #ADFF2F 0%, #32CD32 30%, #00FF00 60%, #00FA9A 100%)`,
       borderRadius: "inherit",
-      animation: `${progressFillAnimation} 2s ease-out ${delay}s both`,
+      animation: `${progressFillAnimation} 2.5s cubic-bezier(0.4, 0, 0.2, 1) ${delay}s both`,
       "--target-width": `${percentage}%`,
+      zIndex: 1,
+      boxShadow: isWinner
+        ? `inset 0 2px 10px rgba(255, 215, 0, 0.6)`
+        : `inset 0 2px 10px rgba(50, 205, 50, 0.5)`,
     },
   })
 );

--- a/src/crm/components/WildPoll.tsx
+++ b/src/crm/components/WildPoll.tsx
@@ -345,28 +345,52 @@ export default function WildPoll({
               ))}
             </Stack>
             
-            <Box sx={{ mt: 4, textAlign: "center" }}>
+            <Box sx={{ mt: 5, textAlign: "center" }}>
               <Button
                 variant="contained"
                 onClick={handleVote}
                 disabled={!selectedOption}
                 size="large"
                 sx={{
-                  px: 4,
-                  py: 1.5,
-                  fontSize: "1.1rem",
-                  fontWeight: 600,
-                  borderRadius: 3,
+                  px: 6,
+                  py: 2,
+                  fontSize: "1.3rem",
+                  fontWeight: 800,
+                  borderRadius: 5,
                   textTransform: "none",
-                  background: "linear-gradient(45deg, #2196F3 30%, #21CBF3 90%)",
-                  boxShadow: "0 4px 20px rgba(33, 150, 243, 0.3)",
-                  "&:hover": {
-                    transform: "translateY(-2px)",
-                    boxShadow: "0 6px 25px rgba(33, 150, 243, 0.4)",
+                  background: "linear-gradient(135deg, #FFFF00 0%, #FFD700 25%, #32CD32 50%, #00FF00 75%, #ADFF2F 100%)",
+                  border: "3px solid #FFD700",
+                  color: "#1B5E20",
+                  boxShadow: "0 8px 30px rgba(255, 215, 0, 0.6), 0 4px 20px rgba(50, 205, 50, 0.4)",
+                  position: "relative",
+                  overflow: "hidden",
+                  "&:before": {
+                    content: '""',
+                    position: "absolute",
+                    top: 0,
+                    left: "-100%",
+                    width: "100%",
+                    height: "100%",
+                    background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.6), transparent)",
+                    transition: "left 0.8s",
                   },
+                  "&:hover": {
+                    transform: "translateY(-4px) scale(1.05)",
+                    background: "linear-gradient(135deg, #FFFF33 0%, #FFD700 25%, #00FF7F 50%, #32CD32 75%, #90EE90 100%)",
+                    boxShadow: "0 12px 40px rgba(255, 215, 0, 0.8), 0 6px 30px rgba(50, 205, 50, 0.6)",
+                    animation: `${pulseAnimation} 1s ease-in-out infinite`,
+                    "&:before": {
+                      left: "100%",
+                    },
+                  },
+                  "&:disabled": {
+                    background: "linear-gradient(135deg, #CCCCCC 0%, #999999 100%)",
+                    color: "#666666",
+                    boxShadow: "none",
+                  }
                 }}
               >
-                Cast Your Vote 🗳️
+                🌟 CAST YOUR EPIC VOTE! 🚀
               </Button>
             </Box>
           </Box>

--- a/src/crm/components/WildPoll.tsx
+++ b/src/crm/components/WildPoll.tsx
@@ -294,7 +294,14 @@ export default function WildPoll({
           </Box>
         </Box>
 
-        <Divider sx={{ mb: 3, borderWidth: 2, borderColor: "primary.main" }} />
+        <Divider sx={{
+          mb: 4,
+          borderWidth: 3,
+          background: "linear-gradient(90deg, #FFD700 0%, #32CD32 50%, #FFD700 100%)",
+          borderRadius: 2,
+          height: 4,
+          border: "none"
+        }} />
         
         {!hasVoted ? (
           <Box>

--- a/src/crm/components/WildPoll.tsx
+++ b/src/crm/components/WildPoll.tsx
@@ -216,30 +216,78 @@ export default function WildPoll({
     <AnimatedCard sx={{ maxWidth: 700, mx: "auto", mb: 3 }}>
       <CardContent sx={{ p: 3 }}>
         {/* Header */}
-        <Box sx={{ display: "flex", alignItems: "center", mb: 3 }}>
-          <Badge badgeContent={<PollIcon sx={{ fontSize: 16 }} />} color="primary">
-            <Avatar sx={{ bgcolor: "primary.main", mr: 2 }}>
-              <PollIcon />
+        <Box sx={{
+          display: "flex",
+          alignItems: "center",
+          mb: 4,
+          p: 2,
+          background: "linear-gradient(135deg, rgba(255,255,0,0.2) 0%, rgba(50,205,50,0.2) 100%)",
+          borderRadius: 3,
+          border: "2px solid #FFD700",
+          position: "relative",
+          zIndex: 1,
+        }}>
+          <Badge
+            badgeContent={
+              <Box sx={{
+                bgcolor: "#32CD32",
+                borderRadius: "50%",
+                p: 0.5,
+                border: "2px solid #FFD700"
+              }}>
+                <PollIcon sx={{ fontSize: 14, color: "white" }} />
+              </Box>
+            }
+          >
+            <Avatar sx={{
+              bgcolor: "linear-gradient(135deg, #FFD700 0%, #32CD32 100%)",
+              background: "linear-gradient(135deg, #FFD700 0%, #32CD32 100%)",
+              mr: 2,
+              width: 60,
+              height: 60,
+              border: "3px solid #FFFF00",
+              boxShadow: "0 8px 25px rgba(255,215,0,0.5)"
+            }}>
+              <PollIcon sx={{ fontSize: 30, color: "#1B5E20" }} />
             </Avatar>
           </Badge>
           <Box sx={{ flex: 1 }}>
-            <Typography variant="h4" component="h2" sx={{ fontWeight: 700, mb: 0.5 }}>
+            <Typography variant="h4" component="h2" sx={{
+              fontWeight: 800,
+              mb: 1,
+              background: "linear-gradient(135deg, #1B5E20 0%, #2E7D32 100%)",
+              backgroundClip: "text",
+              WebkitBackgroundClip: "text",
+              WebkitTextFillColor: "transparent",
+              textShadow: "2px 2px 4px rgba(255,215,0,0.3)"
+            }}>
               {question}
             </Typography>
             <Stack direction="row" spacing={1} alignItems="center">
-              <Chip 
-                icon={<GroupIcon />} 
-                label={`${totalParticipants} participants`} 
-                size="small" 
-                variant="outlined"
+              <Chip
+                icon={<GroupIcon />}
+                label={`${totalParticipants} participants`}
+                size="medium"
+                sx={{
+                  bgcolor: "#32CD32",
+                  color: "white",
+                  fontWeight: 600,
+                  border: "2px solid #FFD700",
+                  "& .MuiChip-icon": { color: "white" }
+                }}
               />
               {timeRemaining && (
-                <Chip 
-                  icon={<TimerIcon />} 
-                  label={timeRemaining} 
-                  size="small" 
-                  color="warning"
-                  variant="outlined"
+                <Chip
+                  icon={<TimerIcon />}
+                  label={timeRemaining}
+                  size="medium"
+                  sx={{
+                    bgcolor: "#FFD700",
+                    color: "#1B5E20",
+                    fontWeight: 600,
+                    border: "2px solid #32CD32",
+                    "& .MuiChip-icon": { color: "#1B5E20" }
+                  }}
                 />
               )}
             </Stack>

--- a/src/crm/components/WildPoll.tsx
+++ b/src/crm/components/WildPoll.tsx
@@ -453,9 +453,17 @@ export default function WildPoll({
                         </Box>
                         <Chip
                           label={`${option.votes} votes • ${percentage.toFixed(1)}%`}
-                          size="small"
-                          color={isWinner ? "success" : isSelected ? "primary" : "default"}
-                          variant={isWinner || isSelected ? "filled" : "outlined"}
+                          size="medium"
+                          sx={{
+                            bgcolor: isWinner ? "#FFD700" : isSelected ? "#32CD32" : "#90EE90",
+                            color: isWinner ? "#1B5E20" : isSelected ? "white" : "#1B5E20",
+                            fontWeight: 700,
+                            border: isWinner ? "2px solid #32CD32" : isSelected ? "2px solid #FFD700" : "2px solid #32CD32",
+                            boxShadow: isWinner
+                              ? "0 4px 15px rgba(255,215,0,0.5)"
+                              : "0 3px 10px rgba(50,205,50,0.4)",
+                            fontSize: "0.9rem"
+                          }}
                         />
                       </Box>
                       <ResultBar 

--- a/src/crm/components/WildPoll.tsx
+++ b/src/crm/components/WildPoll.tsx
@@ -481,20 +481,40 @@ export default function WildPoll({
               </Stack>
             )}
             
-            <Box sx={{ 
-              mt: 3, 
-              p: 2, 
-              bgcolor: "background.paper", 
-              borderRadius: 2,
-              border: "1px solid",
-              borderColor: "divider"
+            <Box sx={{
+              mt: 4,
+              p: 3,
+              background: "linear-gradient(135deg, #FFFF00 0%, #FFD700 25%, #32CD32 75%, #00FF00 100%)",
+              borderRadius: 4,
+              border: "4px solid #FFD700",
+              boxShadow: "0 8px 30px rgba(255,215,0,0.4), inset 0 2px 10px rgba(255,255,255,0.3)",
+              position: "relative",
+              overflow: "hidden",
+              "&:before": {
+                content: '""',
+                position: "absolute",
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                background: "radial-gradient(circle at 30% 40%, rgba(255,255,255,0.3) 0%, transparent 50%), radial-gradient(circle at 70% 80%, rgba(255,255,255,0.2) 0%, transparent 50%)",
+                pointerEvents: "none",
+              }
             }}>
-              <Stack direction="row" justifyContent="space-between" alignItems="center">
-                <Typography variant="body1" sx={{ fontWeight: 600 }}>
-                  Total Votes: {totalVotes}
+              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ position: "relative", zIndex: 1 }}>
+                <Typography variant="h6" sx={{
+                  fontWeight: 800,
+                  color: "#1B5E20",
+                  textShadow: "1px 1px 2px rgba(255,255,255,0.8)"
+                }}>
+                  🏆 Total Epic Votes: {totalVotes} 🏆
                 </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  Thank you for participating! 🎉
+                <Typography variant="h6" sx={{
+                  color: "#1B5E20",
+                  fontWeight: 700,
+                  textShadow: "1px 1px 2px rgba(255,255,255,0.8)"
+                }}>
+                  THANK YOU FOR THE WILD PARTICIPATION! 🎊🚀✨
                 </Typography>
               </Stack>
             </Box>

--- a/src/crm/components/WildPoll.tsx
+++ b/src/crm/components/WildPoll.tsx
@@ -153,13 +153,18 @@ const ResultBar = styled(Box)<{ percentage: number; isWinner?: boolean; delay?: 
 const ResultLabel = styled(Box)(({ theme }) => ({
   position: "absolute",
   top: "50%",
-  left: 16,
+  left: 20,
   transform: "translateY(-50%)",
-  zIndex: 1,
-  color: theme.palette.text.primary,
-  fontWeight: 600,
-  fontSize: "0.9rem",
-  animation: `${slideInAnimation} 0.8s ease-out 1s both`,
+  zIndex: 3,
+  color: "#1B5E20",
+  fontWeight: 800,
+  fontSize: "1rem",
+  textShadow: "0 2px 4px rgba(255,255,255,0.8)",
+  animation: `${slideInAnimation} 1s ease-out 1.5s both`,
+  background: "rgba(255,255,255,0.2)",
+  borderRadius: "12px",
+  padding: "4px 8px",
+  backdropFilter: "blur(4px)",
 }));
 
 interface PollOption {

--- a/src/crm/components/WildPoll.tsx
+++ b/src/crm/components/WildPoll.tsx
@@ -36,14 +36,28 @@ const progressFillAnimation = keyframes`
 
 // Styled components
 const AnimatedCard = styled(Card)(({ theme }) => ({
-  background: `linear-gradient(135deg, ${theme.palette.primary.main}15 0%, ${theme.palette.secondary.main}15 100%)`,
-  border: `2px solid ${theme.palette.primary.main}30`,
-  borderRadius: 16,
-  boxShadow: `0 8px 32px ${theme.palette.primary.main}20`,
+  background: `linear-gradient(135deg, #FFD700 15%, #32CD32 85%)`,
+  border: `3px solid #FFD700`,
+  borderRadius: 20,
+  boxShadow: `0 12px 40px rgba(255, 215, 0, 0.4)`,
   transition: "all 0.3s ease-in-out",
+  position: "relative",
+  overflow: "hidden",
+  "&:before": {
+    content: '""',
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    background: `radial-gradient(circle at 20% 50%, #FFFF00 0%, transparent 50%), radial-gradient(circle at 80% 50%, #00FF00 0%, transparent 50%)`,
+    opacity: 0.1,
+    pointerEvents: "none",
+  },
   "&:hover": {
-    transform: "translateY(-4px)",
-    boxShadow: `0 12px 40px ${theme.palette.primary.main}30`,
+    transform: "translateY(-8px) rotateX(2deg)",
+    boxShadow: `0 20px 60px rgba(255, 215, 0, 0.6), 0 8px 32px rgba(50, 205, 50, 0.4)`,
+    filter: "brightness(1.1)",
   },
 }));
 

--- a/src/crm/pages/Polls.tsx
+++ b/src/crm/pages/Polls.tsx
@@ -1,0 +1,190 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Container from "@mui/material/Container";
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import Chip from "@mui/material/Chip";
+import Divider from "@mui/material/Divider";
+import PollIcon from "@mui/icons-material/Poll";
+import TrendingUpIcon from "@mui/icons-material/TrendingUp";
+import BasicPoll from "../components/BasicPoll";
+import WildPoll from "../components/WildPoll";
+
+export default function Polls() {
+  // Sample data for basic poll
+  const [basicPollOptions, setBasicPollOptions] = React.useState([
+    { id: "option1", text: "Remote work", votes: 45 },
+    { id: "option2", text: "Hybrid work", votes: 32 },
+    { id: "option3", text: "Office work", votes: 18 },
+    { id: "option4", text: "Flexible schedule", votes: 27 },
+  ]);
+
+  // Sample data for wild poll
+  const [wildPollOptions, setWildPollOptions] = React.useState([
+    { 
+      id: "pizza", 
+      text: "Pizza Party", 
+      votes: 23, 
+      emoji: "🍕", 
+      description: "Classic pizza with everyone's favorite toppings" 
+    },
+    { 
+      id: "bbq", 
+      text: "BBQ Cookout", 
+      votes: 18, 
+      emoji: "🔥", 
+      description: "Outdoor grilling with burgers and hotdogs" 
+    },
+    { 
+      id: "potluck", 
+      text: "Potluck Dinner", 
+      votes: 31, 
+      emoji: "🥘", 
+      description: "Everyone brings their signature dish" 
+    },
+    { 
+      id: "catering", 
+      text: "Catered Meal", 
+      votes: 12, 
+      emoji: "🍽️", 
+      description: "Professional catering from local restaurant" 
+    },
+  ]);
+
+  const handleBasicPollVote = (optionId: string) => {
+    setBasicPollOptions(prevOptions =>
+      prevOptions.map(option =>
+        option.id === optionId 
+          ? { ...option, votes: option.votes + 1 }
+          : option
+      )
+    );
+  };
+
+  const handleWildPollVote = (optionId: string) => {
+    setWildPollOptions(prevOptions =>
+      prevOptions.map(option =>
+        option.id === optionId 
+          ? { ...option, votes: option.votes + 1 }
+          : option
+      )
+    );
+  };
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      {/* Page Header */}
+      <Paper 
+        elevation={0} 
+        sx={{ 
+          p: 4, 
+          mb: 4, 
+          background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
+          color: "white",
+          borderRadius: 3
+        }}
+      >
+        <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 2 }}>
+          <PollIcon sx={{ fontSize: 40 }} />
+          <Typography variant="h3" component="h1" sx={{ fontWeight: 700 }}>
+            Company Polls
+          </Typography>
+        </Stack>
+        <Typography variant="h6" sx={{ opacity: 0.9, maxWidth: 600 }}>
+          Voice your opinion on important company decisions. Your feedback helps us make better choices for everyone.
+        </Typography>
+        <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+          <Chip 
+            label="Interactive" 
+            size="small" 
+            sx={{ backgroundColor: "rgba(255,255,255,0.2)", color: "white" }}
+          />
+          <Chip 
+            label="Real-time Results" 
+            size="small" 
+            sx={{ backgroundColor: "rgba(255,255,255,0.2)", color: "white" }}
+          />
+          <Chip 
+            label="Anonymous" 
+            size="small" 
+            sx={{ backgroundColor: "rgba(255,255,255,0.2)", color: "white" }}
+          />
+        </Stack>
+      </Paper>
+
+      {/* Basic Poll Section */}
+      <Box sx={{ mb: 6 }}>
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 3 }}>
+          <PollIcon color="primary" />
+          <Typography variant="h4" component="h2" sx={{ fontWeight: 600 }}>
+            Basic Poll Example
+          </Typography>
+          <Chip label="Simple & Clean" variant="outlined" size="small" />
+        </Stack>
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 3, maxWidth: 700 }}>
+          A straightforward polling interface with essential functionality. Perfect for quick decisions and simple questions.
+        </Typography>
+        
+        <BasicPoll
+          question="What's your preferred work arrangement?"
+          options={basicPollOptions}
+          onVote={handleBasicPollVote}
+        />
+      </Box>
+
+      <Divider sx={{ my: 6, borderWidth: 2, borderColor: "primary.main" }} />
+
+      {/* Wild Poll Section */}
+      <Box sx={{ mb: 6 }}>
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 3 }}>
+          <TrendingUpIcon color="secondary" />
+          <Typography variant="h4" component="h2" sx={{ fontWeight: 600 }}>
+            Enhanced Poll Example
+          </Typography>
+          <Chip label="Animated & Interactive" variant="outlined" size="small" color="secondary" />
+        </Stack>
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 3, maxWidth: 700 }}>
+          A feature-rich polling component with animations, emojis, descriptions, and real-time visual feedback. 
+          Great for engaging team events and important decisions.
+        </Typography>
+        
+        <WildPoll
+          question="What should we do for the next team event?"
+          options={wildPollOptions}
+          totalParticipants={84}
+          timeRemaining="2 days left"
+          onVote={handleWildPollVote}
+        />
+      </Box>
+
+      {/* Footer Info */}
+      <Paper 
+        elevation={0} 
+        sx={{ 
+          p: 3, 
+          backgroundColor: "grey.50", 
+          borderRadius: 2,
+          border: "1px solid",
+          borderColor: "divider"
+        }}
+      >
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Box>
+            <Typography variant="h6" sx={{ fontWeight: 600, mb: 0.5 }}>
+              Poll Features
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Real-time voting • Anonymous responses • Visual results • Mobile-friendly
+            </Typography>
+          </Box>
+          <Stack direction="row" spacing={1}>
+            <Chip label="✨ Interactive" size="small" />
+            <Chip label="📊 Analytics" size="small" />
+            <Chip label="🎨 Customizable" size="small" />
+          </Stack>
+        </Stack>
+      </Paper>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Purpose
The user requested the creation of two polling components - one basic and one "wild" - that ask questions with four choices and display results after voting. The second component was specifically requested to be enhanced with vibrant yellows and greens throughout the design.

## Code changes
- **New Polls page**: Created `/polls` route with comprehensive polling examples and navigation integration
- **BasicPoll component**: Simple, clean polling interface with radio buttons, vote submission, and results display using Material-UI components
- **WildPoll component**: Enhanced polling component featuring:
  - Animated gradient backgrounds using yellows and greens
  - Emoji support and option descriptions
  - Keyframe animations for pulse effects and progress bars
  - Advanced styling with badges, chips, and visual feedback
  - Real-time result visualization with winner highlighting
- **Navigation updates**: Added "Polls" menu item with poll icon to both desktop and mobile navigation menus
- **Routing**: Integrated polls page into the CRM dashboard routing system

The implementation provides both a minimal polling solution and a feature-rich, visually engaging alternative with the requested yellow/green color scheme and animations.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f325fd1fccb44259b91210edc9d123e5/nova-garden)

👀 [Preview Link](https://f325fd1fccb44259b91210edc9d123e5-nova-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f325fd1fccb44259b91210edc9d123e5</projectId>-->
<!--<branchName>nova-garden</branchName>-->