### PR TITLE
feat: Add customer management prototype pages

### DIFF
--- a/src/crm/CrmDashboard.tsx
+++ b/src/crm/CrmDashboard.tsx
@@ -13,6 +13,9 @@ import CrmHeader from "./components/CrmHeader";
 import CrmSideMenu from "./components/CrmSideMenu";
 import CrmMainDashboard from "./components/CrmMainDashboard";
 import Customers from "./pages/Customers";
+import CustomersV1 from "./pages/CustomersV1";
+import CustomersV2 from "./pages/CustomersV2";
+import CustomersV3 from "./pages/CustomersV3";
 import Deals from "./pages/Deals";
 import Contacts from "./pages/Contacts";
 import Tasks from "./pages/Tasks";
@@ -64,6 +67,9 @@ export default function CrmDashboard() {
             <Routes>
               <Route index element={<CrmMainDashboard />} />
               <Route path="customers" element={<Customers />} />
+              <Route path="customers-v1" element={<CustomersV1 />} />
+              <Route path="customers-v2" element={<CustomersV2 />} />
+              <Route path="customers-v3" element={<CustomersV3 />} />
               <Route path="deals" element={<Deals />} />
               <Route path="contacts" element={<Contacts />} />
               <Route path="tasks" element={<Tasks />} />

--- a/src/crm/components/CrmMenuContent.tsx
+++ b/src/crm/components/CrmMenuContent.tsx
@@ -20,6 +20,9 @@ import HelpOutlineRoundedIcon from "@mui/icons-material/HelpOutlineRounded";
 const mainListItems = [
   { text: "Dashboard", icon: <DashboardRoundedIcon />, path: "/" },
   { text: "Customers", icon: <PeopleRoundedIcon />, path: "/customers" },
+  { text: "Customers v1", icon: <PeopleRoundedIcon />, path: "/customers-v1" },
+  { text: "Customers v2", icon: <PeopleRoundedIcon />, path: "/customers-v2" },
+  { text: "Customers v3", icon: <PeopleRoundedIcon />, path: "/customers-v3" },
   { text: "Deals", icon: <BusinessCenterRoundedIcon />, path: "/deals" },
   { text: "Contacts", icon: <ContactsRoundedIcon />, path: "/contacts" },
   { text: "Tasks", icon: <AssignmentRoundedIcon />, path: "/tasks" },

--- a/src/crm/components/CustomerCard.tsx
+++ b/src/crm/components/CustomerCard.tsx
@@ -1,0 +1,74 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Avatar from "@mui/material/Avatar";
+import Button from "@mui/material/Button";
+
+interface CustomerCardProps {
+  customer: {
+    login: {
+      uuid: string;
+      username: string;
+    };
+    name: {
+      title: string;
+      first: string;
+      last: string;
+    };
+    email: string;
+    location: {
+      city: string;
+      country: string;
+    };
+    phone: string;
+    picture: {
+      large: string;
+      medium: string;
+      thumbnail: string;
+    };
+  };
+}
+
+export default function CustomerCard({ customer }: CustomerCardProps) {
+  return (
+    <Box
+      sx={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        borderRadius: 1,
+        border: "1px solid",
+        borderColor: "divider",
+        overflow: "hidden",
+        transition: "box-shadow 0.3s ease-in-out",
+        "&:hover": {
+          boxShadow: 2,
+        },
+      }}
+    >
+      <Box sx={{ flexGrow: 1, textAlign: "center", p: 2 }}>
+        <Avatar
+          src={customer.picture.large}
+          alt={`${customer.name.first} ${customer.name.last}`}
+          sx={{ width: 80, height: 80, mx: "auto", mb: 2 }}
+        />
+        <Typography variant="h6" component="h2" gutterBottom>
+          {customer.name.first} {customer.name.last}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          {customer.email}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {customer.location.city}, {customer.location.country}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+          {customer.phone}
+        </Typography>
+      </Box>
+      <Box sx={{ display: "flex", justifyContent: "center", gap: 1, pb: 2 }}>
+        <Button size="small">View Details</Button>
+        <Button size="small">Edit</Button>
+      </Box>
+    </Box>
+  );
+}

--- a/src/crm/pages/CustomersV1.tsx
+++ b/src/crm/pages/CustomersV1.tsx
@@ -1,0 +1,289 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Grid from "@mui/material/Grid";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import CardActions from "@mui/material/CardActions";
+import Avatar from "@mui/material/Avatar";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import InputAdornment from "@mui/material/InputAdornment";
+import SearchIcon from "@mui/icons-material/Search";
+import AddIcon from "@mui/icons-material/Add";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Stack from "@mui/material/Stack";
+import CircularProgress from "@mui/material/CircularProgress";
+import Alert from "@mui/material/Alert";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  email: string;
+  location: {
+    city: string;
+    country: string;
+  };
+  phone: string;
+  picture: {
+    large: string;
+    medium: string;
+    thumbnail: string;
+  };
+}
+
+interface ApiResponse {
+  page: number;
+  perPage: number;
+  total: number;
+  data: User[];
+}
+
+export default function CustomersV1() {
+  const [customers, setCustomers] = React.useState<User[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [searchTerm, setSearchTerm] = React.useState("");
+  const [openDialog, setOpenDialog] = React.useState(false);
+  const [newCustomer, setNewCustomer] = React.useState({
+    email: "",
+    username: "",
+    firstName: "",
+    lastName: "",
+    title: "Mr",
+    city: "",
+    country: "",
+  });
+  const [creating, setCreating] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    fetchCustomers();
+  }, [searchTerm]);
+
+  const fetchCustomers = async () => {
+    try {
+      setLoading(true);
+      const url = searchTerm
+        ? `https://user-api.builder-io.workers.dev/api/users?search=${encodeURIComponent(searchTerm)}&perPage=20`
+        : "https://user-api.builder-io.workers.dev/api/users?perPage=20";
+      
+      const response = await fetch(url);
+      const data: ApiResponse = await response.json();
+      setCustomers(data.data);
+      setError(null);
+    } catch (err) {
+      setError("Failed to load customers");
+      console.error("Error fetching customers:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreateCustomer = async () => {
+    try {
+      setCreating(true);
+      const response = await fetch("https://user-api.builder-io.workers.dev/api/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: newCustomer.email,
+          login: {
+            username: newCustomer.username,
+            password: "defaultPassword123",
+          },
+          name: {
+            first: newCustomer.firstName,
+            last: newCustomer.lastName,
+            title: newCustomer.title,
+          },
+          location: {
+            city: newCustomer.city,
+            country: newCustomer.country,
+            street: {
+              number: 123,
+              name: "Main St",
+            },
+            state: "",
+            postcode: "00000",
+          },
+        }),
+      });
+
+      if (response.ok) {
+        setOpenDialog(false);
+        setNewCustomer({
+          email: "",
+          username: "",
+          firstName: "",
+          lastName: "",
+          title: "Mr",
+          city: "",
+          country: "",
+        });
+        fetchCustomers();
+      } else {
+        setError("Failed to create customer");
+      }
+    } catch (err) {
+      setError("Failed to create customer");
+      console.error("Error creating customer:", err);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(event.target.value);
+  };
+
+  return (
+    <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" } }}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 3 }}>
+        <Typography variant="h4" component="h1" sx={{ fontWeight: 600 }}>
+          Customers v1
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => setOpenDialog(true)}
+        >
+          Create Customer
+        </Button>
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      <TextField
+        fullWidth
+        placeholder="Search customers..."
+        value={searchTerm}
+        onChange={handleSearchChange}
+        sx={{ mb: 3 }}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon />
+            </InputAdornment>
+          ),
+        }}
+      />
+
+      {loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <Grid container spacing={3}>
+          {customers.map((customer) => (
+            <Grid item xs={12} sm={6} md={4} lg={3} key={customer.login.uuid}>
+              <Card sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+                <CardContent sx={{ flexGrow: 1, textAlign: "center" }}>
+                  <Avatar
+                    src={customer.picture.large}
+                    alt={`${customer.name.first} ${customer.name.last}`}
+                    sx={{ width: 80, height: 80, mx: "auto", mb: 2 }}
+                  />
+                  <Typography variant="h6" component="h2" gutterBottom>
+                    {customer.name.first} {customer.name.last}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary" gutterBottom>
+                    {customer.email}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {customer.location.city}, {customer.location.country}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                    {customer.phone}
+                  </Typography>
+                </CardContent>
+                <CardActions sx={{ justifyContent: "center", pb: 2 }}>
+                  <Button size="small">View Details</Button>
+                  <Button size="small">Edit</Button>
+                </CardActions>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      )}
+
+      <Dialog open={openDialog} onClose={() => setOpenDialog(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Create New Customer</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <TextField
+              label="Email"
+              type="email"
+              fullWidth
+              required
+              value={newCustomer.email}
+              onChange={(e) => setNewCustomer({ ...newCustomer, email: e.target.value })}
+            />
+            <TextField
+              label="Username"
+              fullWidth
+              required
+              value={newCustomer.username}
+              onChange={(e) => setNewCustomer({ ...newCustomer, username: e.target.value })}
+            />
+            <Stack direction="row" spacing={2}>
+              <TextField
+                label="First Name"
+                fullWidth
+                required
+                value={newCustomer.firstName}
+                onChange={(e) => setNewCustomer({ ...newCustomer, firstName: e.target.value })}
+              />
+              <TextField
+                label="Last Name"
+                fullWidth
+                required
+                value={newCustomer.lastName}
+                onChange={(e) => setNewCustomer({ ...newCustomer, lastName: e.target.value })}
+              />
+            </Stack>
+            <Stack direction="row" spacing={2}>
+              <TextField
+                label="City"
+                fullWidth
+                value={newCustomer.city}
+                onChange={(e) => setNewCustomer({ ...newCustomer, city: e.target.value })}
+              />
+              <TextField
+                label="Country"
+                fullWidth
+                value={newCustomer.country}
+                onChange={(e) => setNewCustomer({ ...newCustomer, country: e.target.value })}
+              />
+            </Stack>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenDialog(false)}>Cancel</Button>
+          <Button
+            onClick={handleCreateCustomer}
+            variant="contained"
+            disabled={creating || !newCustomer.email || !newCustomer.username || !newCustomer.firstName || !newCustomer.lastName}
+          >
+            {creating ? "Creating..." : "Create"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/crm/pages/CustomersV1.tsx
+++ b/src/crm/pages/CustomersV1.tsx
@@ -2,10 +2,6 @@ import * as React from "react";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import Grid from "@mui/material/Grid";
-import Card from "@mui/material/Card";
-import CardContent from "@mui/material/CardContent";
-import CardActions from "@mui/material/CardActions";
-import Avatar from "@mui/material/Avatar";
 import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import InputAdornment from "@mui/material/InputAdornment";
@@ -18,6 +14,7 @@ import DialogActions from "@mui/material/DialogActions";
 import Stack from "@mui/material/Stack";
 import CircularProgress from "@mui/material/CircularProgress";
 import Alert from "@mui/material/Alert";
+import CustomerCard from "../components/CustomerCard";
 
 interface User {
   login: {
@@ -192,31 +189,7 @@ export default function CustomersV1() {
         <Grid container spacing={3}>
           {customers.map((customer) => (
             <Grid item xs={12} sm={6} md={4} lg={3} key={customer.login.uuid}>
-              <Card sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
-                <CardContent sx={{ flexGrow: 1, textAlign: "center" }}>
-                  <Avatar
-                    src={customer.picture.large}
-                    alt={`${customer.name.first} ${customer.name.last}`}
-                    sx={{ width: 80, height: 80, mx: "auto", mb: 2 }}
-                  />
-                  <Typography variant="h6" component="h2" gutterBottom>
-                    {customer.name.first} {customer.name.last}
-                  </Typography>
-                  <Typography variant="body2" color="text.secondary" gutterBottom>
-                    {customer.email}
-                  </Typography>
-                  <Typography variant="body2" color="text.secondary">
-                    {customer.location.city}, {customer.location.country}
-                  </Typography>
-                  <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-                    {customer.phone}
-                  </Typography>
-                </CardContent>
-                <CardActions sx={{ justifyContent: "center", pb: 2 }}>
-                  <Button size="small">View Details</Button>
-                  <Button size="small">Edit</Button>
-                </CardActions>
-              </Card>
+              <CustomerCard customer={customer} />
             </Grid>
           ))}
         </Grid>

--- a/src/crm/pages/CustomersV2.tsx
+++ b/src/crm/pages/CustomersV2.tsx
@@ -221,6 +221,61 @@ export default function CustomersV2() {
 
   return (
     <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" } }}>
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: "48px", mb: 2, border: "2px solid hsl(45, 94%, 80%)", p: 2 }}>
+        <Box sx={{ display: "flex", alignItems: "center", lineHeight: "20px" }}>
+          Active View:
+        </Box>
+        {savedViews.map((view) => (
+          <Box
+            key={view.id}
+            role="button"
+            tabIndex={0}
+            onClick={() => handleLoadView(view)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                handleLoadView(view);
+              }
+            }}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              backgroundColor: activeView === view.id ? "rgb(2, 122, 242)" : "rgb(235, 238, 244)",
+              borderColor: activeView === view.id ? "rgb(230, 242, 255)" : "rgb(218, 222, 231)",
+              borderRadius: "999px",
+              borderWidth: "1px",
+              borderStyle: "solid",
+              color: activeView === view.id ? "rgb(230, 242, 255)" : "rgb(86, 100, 129)",
+              fontSize: "13px",
+              height: "24px",
+              justifyContent: "center",
+              lineHeight: "19.5px",
+              maxHeight: "20px",
+              maxWidth: "100%",
+              position: "relative",
+              textWrap: "nowrap",
+              userSelect: "none",
+              cursor: "pointer",
+              transition: "background-color 0.3s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+              px: 1,
+              "&:hover": {
+                backgroundColor: activeView === view.id ? "rgb(1, 102, 200)" : "rgb(220, 225, 235)",
+              },
+              "& > div": {
+                display: "block",
+                fontSize: "12px",
+                fontWeight: "600",
+                lineHeight: "18px",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              },
+            }}
+          >
+            <div>{view.name}</div>
+          </Box>
+        ))}
+      </Box>
+
       <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 3 }}>
         <Typography variant="h4" component="h1" sx={{ fontWeight: 600 }}>
           Customers v2
@@ -296,21 +351,6 @@ export default function CustomersV2() {
           </Stack>
         )}
       </Paper>
-
-      <Stack direction="row" spacing={1} sx={{ mb: 2, flexWrap: "wrap", gap: 1 }}>
-        <Typography variant="body2" sx={{ display: "flex", alignItems: "center", mr: 1 }}>
-          Active View:
-        </Typography>
-        {savedViews.map((view) => (
-          <Chip
-            key={view.id}
-            label={view.name}
-            onClick={() => handleLoadView(view)}
-            color={activeView === view.id ? "primary" : "default"}
-            variant={activeView === view.id ? "filled" : "outlined"}
-          />
-        ))}
-      </Stack>
 
       {loading ? (
         <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>

--- a/src/crm/pages/CustomersV2.tsx
+++ b/src/crm/pages/CustomersV2.tsx
@@ -1,0 +1,493 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import InputAdornment from "@mui/material/InputAdornment";
+import SearchIcon from "@mui/icons-material/Search";
+import AddIcon from "@mui/icons-material/Add";
+import FilterListIcon from "@mui/icons-material/FilterList";
+import SaveIcon from "@mui/icons-material/Save";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Stack from "@mui/material/Stack";
+import Chip from "@mui/material/Chip";
+import Paper from "@mui/material/Paper";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Avatar from "@mui/material/Avatar";
+import Checkbox from "@mui/material/Checkbox";
+import CircularProgress from "@mui/material/CircularProgress";
+import Alert from "@mui/material/Alert";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import Drawer from "@mui/material/Drawer";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
+import Divider from "@mui/material/Divider";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  email: string;
+  location: {
+    city: string;
+    country: string;
+  };
+  phone: string;
+  picture: {
+    large: string;
+    medium: string;
+    thumbnail: string;
+  };
+}
+
+interface ApiResponse {
+  page: number;
+  perPage: number;
+  total: number;
+  data: User[];
+}
+
+interface SavedView {
+  id: string;
+  name: string;
+  filters: {
+    search: string;
+    sortBy: string;
+  };
+}
+
+export default function CustomersV2() {
+  const [customers, setCustomers] = React.useState<User[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [searchTerm, setSearchTerm] = React.useState("");
+  const [sortBy, setSortBy] = React.useState("name.first");
+  const [openDialog, setOpenDialog] = React.useState(false);
+  const [openFilterDrawer, setOpenFilterDrawer] = React.useState(false);
+  const [openSaveViewDialog, setOpenSaveViewDialog] = React.useState(false);
+  const [selectedCustomers, setSelectedCustomers] = React.useState<string[]>([]);
+  const [newCustomer, setNewCustomer] = React.useState({
+    email: "",
+    username: "",
+    firstName: "",
+    lastName: "",
+    title: "Mr",
+    city: "",
+    country: "",
+  });
+  const [savedViews, setSavedViews] = React.useState<SavedView[]>([
+    { id: "1", name: "All Customers", filters: { search: "", sortBy: "name.first" } },
+    { id: "2", name: "Recent Contacts", filters: { search: "", sortBy: "registered.date" } },
+    { id: "3", name: "By Location", filters: { search: "", sortBy: "location.city" } },
+  ]);
+  const [activeView, setActiveView] = React.useState<string>("1");
+  const [newViewName, setNewViewName] = React.useState("");
+  const [creating, setCreating] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    fetchCustomers();
+  }, [searchTerm, sortBy]);
+
+  const fetchCustomers = async () => {
+    try {
+      setLoading(true);
+      let url = `https://user-api.builder-io.workers.dev/api/users?perPage=50&sortBy=${sortBy}`;
+      if (searchTerm) {
+        url += `&search=${encodeURIComponent(searchTerm)}`;
+      }
+      
+      const response = await fetch(url);
+      const data: ApiResponse = await response.json();
+      setCustomers(data.data);
+      setError(null);
+    } catch (err) {
+      setError("Failed to load customers");
+      console.error("Error fetching customers:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreateCustomer = async () => {
+    try {
+      setCreating(true);
+      const response = await fetch("https://user-api.builder-io.workers.dev/api/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: newCustomer.email,
+          login: {
+            username: newCustomer.username,
+            password: "defaultPassword123",
+          },
+          name: {
+            first: newCustomer.firstName,
+            last: newCustomer.lastName,
+            title: newCustomer.title,
+          },
+          location: {
+            city: newCustomer.city,
+            country: newCustomer.country,
+            street: {
+              number: 123,
+              name: "Main St",
+            },
+            state: "",
+            postcode: "00000",
+          },
+        }),
+      });
+
+      if (response.ok) {
+        setOpenDialog(false);
+        setNewCustomer({
+          email: "",
+          username: "",
+          firstName: "",
+          lastName: "",
+          title: "Mr",
+          city: "",
+          country: "",
+        });
+        fetchCustomers();
+      } else {
+        setError("Failed to create customer");
+      }
+    } catch (err) {
+      setError("Failed to create customer");
+      console.error("Error creating customer:", err);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleSelectAll = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.checked) {
+      setSelectedCustomers(customers.map((c) => c.login.uuid));
+    } else {
+      setSelectedCustomers([]);
+    }
+  };
+
+  const handleSelectOne = (uuid: string) => {
+    setSelectedCustomers((prev) =>
+      prev.includes(uuid) ? prev.filter((id) => id !== uuid) : [...prev, uuid]
+    );
+  };
+
+  const handleLoadView = (view: SavedView) => {
+    setActiveView(view.id);
+    setSearchTerm(view.filters.search);
+    setSortBy(view.filters.sortBy);
+  };
+
+  const handleSaveView = () => {
+    if (newViewName.trim()) {
+      const newView: SavedView = {
+        id: Date.now().toString(),
+        name: newViewName,
+        filters: {
+          search: searchTerm,
+          sortBy,
+        },
+      };
+      setSavedViews([...savedViews, newView]);
+      setActiveView(newView.id);
+      setNewViewName("");
+      setOpenSaveViewDialog(false);
+    }
+  };
+
+  return (
+    <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" } }}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 3 }}>
+        <Typography variant="h4" component="h1" sx={{ fontWeight: 600 }}>
+          Customers v2
+        </Typography>
+        <Stack direction="row" spacing={1}>
+          <Button
+            variant="outlined"
+            startIcon={<FilterListIcon />}
+            onClick={() => setOpenFilterDrawer(true)}
+          >
+            Views
+          </Button>
+          <Button
+            variant="outlined"
+            startIcon={<SaveIcon />}
+            onClick={() => setOpenSaveViewDialog(true)}
+          >
+            Save View
+          </Button>
+          <Button
+            variant="contained"
+            startIcon={<AddIcon />}
+            onClick={() => setOpenDialog(true)}
+          >
+            Create Customer
+          </Button>
+        </Stack>
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      <Paper sx={{ mb: 2, p: 2 }}>
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems="center">
+          <TextField
+            fullWidth
+            placeholder="Search by name, email, or city..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon />
+                </InputAdornment>
+              ),
+            }}
+          />
+          <FormControl sx={{ minWidth: 200 }}>
+            <InputLabel>Sort By</InputLabel>
+            <Select
+              value={sortBy}
+              label="Sort By"
+              onChange={(e) => setSortBy(e.target.value)}
+            >
+              <MenuItem value="name.first">First Name</MenuItem>
+              <MenuItem value="name.last">Last Name</MenuItem>
+              <MenuItem value="location.city">City</MenuItem>
+              <MenuItem value="location.country">Country</MenuItem>
+              <MenuItem value="registered.date">Registration Date</MenuItem>
+            </Select>
+          </FormControl>
+        </Stack>
+
+        {selectedCustomers.length > 0 && (
+          <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+            <Chip
+              label={`${selectedCustomers.length} selected`}
+              onDelete={() => setSelectedCustomers([])}
+            />
+          </Stack>
+        )}
+      </Paper>
+
+      <Stack direction="row" spacing={1} sx={{ mb: 2, flexWrap: "wrap", gap: 1 }}>
+        <Typography variant="body2" sx={{ display: "flex", alignItems: "center", mr: 1 }}>
+          Active View:
+        </Typography>
+        {savedViews.map((view) => (
+          <Chip
+            key={view.id}
+            label={view.name}
+            onClick={() => handleLoadView(view)}
+            color={activeView === view.id ? "primary" : "default"}
+            variant={activeView === view.id ? "filled" : "outlined"}
+          />
+        ))}
+      </Stack>
+
+      {loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <TableContainer component={Paper}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell padding="checkbox">
+                  <Checkbox
+                    indeterminate={
+                      selectedCustomers.length > 0 && selectedCustomers.length < customers.length
+                    }
+                    checked={customers.length > 0 && selectedCustomers.length === customers.length}
+                    onChange={handleSelectAll}
+                  />
+                </TableCell>
+                <TableCell>Name</TableCell>
+                <TableCell>Email</TableCell>
+                <TableCell>Phone</TableCell>
+                <TableCell>Location</TableCell>
+                <TableCell>Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {customers.map((customer) => (
+                <TableRow
+                  key={customer.login.uuid}
+                  hover
+                  selected={selectedCustomers.includes(customer.login.uuid)}
+                >
+                  <TableCell padding="checkbox">
+                    <Checkbox
+                      checked={selectedCustomers.includes(customer.login.uuid)}
+                      onChange={() => handleSelectOne(customer.login.uuid)}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Stack direction="row" spacing={2} alignItems="center">
+                      <Avatar src={customer.picture.thumbnail} />
+                      <Box>
+                        <Typography variant="body2" fontWeight={500}>
+                          {customer.name.first} {customer.name.last}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          @{customer.login.username}
+                        </Typography>
+                      </Box>
+                    </Stack>
+                  </TableCell>
+                  <TableCell>{customer.email}</TableCell>
+                  <TableCell>{customer.phone}</TableCell>
+                  <TableCell>
+                    {customer.location.city}, {customer.location.country}
+                  </TableCell>
+                  <TableCell>
+                    <Button size="small">View</Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      <Drawer
+        anchor="left"
+        open={openFilterDrawer}
+        onClose={() => setOpenFilterDrawer(false)}
+      >
+        <Box sx={{ width: 300, p: 2 }}>
+          <Typography variant="h6" gutterBottom>
+            Saved Views
+          </Typography>
+          <Divider sx={{ mb: 2 }} />
+          <List>
+            {savedViews.map((view) => (
+              <ListItem key={view.id} disablePadding>
+                <ListItemButton
+                  selected={activeView === view.id}
+                  onClick={() => {
+                    handleLoadView(view);
+                    setOpenFilterDrawer(false);
+                  }}
+                >
+                  <ListItemText primary={view.name} />
+                </ListItemButton>
+              </ListItem>
+            ))}
+          </List>
+        </Box>
+      </Drawer>
+
+      <Dialog open={openDialog} onClose={() => setOpenDialog(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Create New Customer</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <TextField
+              label="Email"
+              type="email"
+              fullWidth
+              required
+              value={newCustomer.email}
+              onChange={(e) => setNewCustomer({ ...newCustomer, email: e.target.value })}
+            />
+            <TextField
+              label="Username"
+              fullWidth
+              required
+              value={newCustomer.username}
+              onChange={(e) => setNewCustomer({ ...newCustomer, username: e.target.value })}
+            />
+            <Stack direction="row" spacing={2}>
+              <TextField
+                label="First Name"
+                fullWidth
+                required
+                value={newCustomer.firstName}
+                onChange={(e) => setNewCustomer({ ...newCustomer, firstName: e.target.value })}
+              />
+              <TextField
+                label="Last Name"
+                fullWidth
+                required
+                value={newCustomer.lastName}
+                onChange={(e) => setNewCustomer({ ...newCustomer, lastName: e.target.value })}
+              />
+            </Stack>
+            <Stack direction="row" spacing={2}>
+              <TextField
+                label="City"
+                fullWidth
+                value={newCustomer.city}
+                onChange={(e) => setNewCustomer({ ...newCustomer, city: e.target.value })}
+              />
+              <TextField
+                label="Country"
+                fullWidth
+                value={newCustomer.country}
+                onChange={(e) => setNewCustomer({ ...newCustomer, country: e.target.value })}
+              />
+            </Stack>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenDialog(false)}>Cancel</Button>
+          <Button
+            onClick={handleCreateCustomer}
+            variant="contained"
+            disabled={creating || !newCustomer.email || !newCustomer.username || !newCustomer.firstName || !newCustomer.lastName}
+          >
+            {creating ? "Creating..." : "Create"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={openSaveViewDialog} onClose={() => setOpenSaveViewDialog(false)}>
+        <DialogTitle>Save Current View</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            margin="dense"
+            label="View Name"
+            fullWidth
+            value={newViewName}
+            onChange={(e) => setNewViewName(e.target.value)}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenSaveViewDialog(false)}>Cancel</Button>
+          <Button onClick={handleSaveView} variant="contained" disabled={!newViewName.trim()}>
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/crm/pages/CustomersV3.tsx
+++ b/src/crm/pages/CustomersV3.tsx
@@ -1,0 +1,492 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Stack from "@mui/material/Stack";
+import Paper from "@mui/material/Paper";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Avatar from "@mui/material/Avatar";
+import Checkbox from "@mui/material/Checkbox";
+import CircularProgress from "@mui/material/CircularProgress";
+import Alert from "@mui/material/Alert";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import AddIcon from "@mui/icons-material/Add";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import TableSortLabel from "@mui/material/TableSortLabel";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  email: string;
+  location: {
+    city: string;
+    country: string;
+    street: {
+      number: number;
+      name: string;
+    };
+    state: string;
+    postcode: string;
+  };
+  phone: string;
+  cell: string;
+  picture: {
+    large: string;
+    medium: string;
+    thumbnail: string;
+  };
+  dob?: {
+    age: number;
+  };
+}
+
+interface ApiResponse {
+  page: number;
+  perPage: number;
+  total: number;
+  data: User[];
+}
+
+export default function CustomersV3() {
+  const [customers, setCustomers] = React.useState<User[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [searchTerm, setSearchTerm] = React.useState("");
+  const [selectedCustomer, setSelectedCustomer] = React.useState<User | null>(null);
+  const [openDialog, setOpenDialog] = React.useState(false);
+  const [editedCustomer, setEditedCustomer] = React.useState<User | null>(null);
+  const [newCustomer, setNewCustomer] = React.useState({
+    email: "",
+    username: "",
+    firstName: "",
+    lastName: "",
+    title: "Mr",
+    city: "",
+    country: "",
+  });
+  const [creating, setCreating] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [sortField, setSortField] = React.useState("name");
+  const [sortDirection, setSortDirection] = React.useState<"asc" | "desc">("asc");
+
+  React.useEffect(() => {
+    fetchCustomers();
+  }, [searchTerm]);
+
+  const fetchCustomers = async () => {
+    try {
+      setLoading(true);
+      let url = `https://user-api.builder-io.workers.dev/api/users?perPage=50`;
+      if (searchTerm) {
+        url += `&search=${encodeURIComponent(searchTerm)}`;
+      }
+      
+      const response = await fetch(url);
+      const data: ApiResponse = await response.json();
+      setCustomers(data.data);
+      setError(null);
+    } catch (err) {
+      setError("Failed to load customers");
+      console.error("Error fetching customers:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreateCustomer = async () => {
+    try {
+      setCreating(true);
+      const response = await fetch("https://user-api.builder-io.workers.dev/api/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: newCustomer.email,
+          login: {
+            username: newCustomer.username,
+            password: "defaultPassword123",
+          },
+          name: {
+            first: newCustomer.firstName,
+            last: newCustomer.lastName,
+            title: newCustomer.title,
+          },
+          location: {
+            city: newCustomer.city,
+            country: newCustomer.country,
+            street: {
+              number: 123,
+              name: "Main St",
+            },
+            state: "",
+            postcode: "00000",
+          },
+        }),
+      });
+
+      if (response.ok) {
+        setOpenDialog(false);
+        setNewCustomer({
+          email: "",
+          username: "",
+          firstName: "",
+          lastName: "",
+          title: "Mr",
+          city: "",
+          country: "",
+        });
+        fetchCustomers();
+      } else {
+        setError("Failed to create customer");
+      }
+    } catch (err) {
+      setError("Failed to create customer");
+      console.error("Error creating customer:", err);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleRowClick = (customer: User) => {
+    setSelectedCustomer(customer);
+    setEditedCustomer({ ...customer });
+  };
+
+  const handleUpdateField = (field: string, value: string) => {
+    if (!editedCustomer) return;
+    
+    const fields = field.split(".");
+    const updated = { ...editedCustomer };
+    
+    if (fields.length === 2) {
+      (updated as any)[fields[0]][fields[1]] = value;
+    } else {
+      (updated as any)[field] = value;
+    }
+    
+    setEditedCustomer(updated);
+  };
+
+  const handleSaveCustomer = async () => {
+    if (!editedCustomer) return;
+    
+    try {
+      const response = await fetch(
+        `https://user-api.builder-io.workers.dev/api/users/${editedCustomer.login.uuid}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(editedCustomer),
+        }
+      );
+
+      if (response.ok) {
+        setSelectedCustomer(editedCustomer);
+        fetchCustomers();
+      } else {
+        setError("Failed to update customer");
+      }
+    } catch (err) {
+      setError("Failed to update customer");
+      console.error("Error updating customer:", err);
+    }
+  };
+
+  const handleSort = (field: string) => {
+    const isAsc = sortField === field && sortDirection === "asc";
+    setSortDirection(isAsc ? "desc" : "asc");
+    setSortField(field);
+  };
+
+  return (
+    <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" } }}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 3 }}>
+        <Typography variant="h4" component="h1" sx={{ fontWeight: 600 }}>
+          Customers v3
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => setOpenDialog(true)}
+        >
+          Create Customer
+        </Button>
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      {selectedCustomer && editedCustomer && (
+        <Paper sx={{ p: 3, mb: 3 }}>
+          <Stack direction="row" spacing={3} alignItems="flex-start">
+            <Avatar
+              src={selectedCustomer.picture.large}
+              alt={`${selectedCustomer.name.first} ${selectedCustomer.name.last}`}
+              sx={{ width: 120, height: 120 }}
+            />
+            <Box sx={{ flex: 1 }}>
+              <Typography variant="h4" gutterBottom>
+                {selectedCustomer.name.first} {selectedCustomer.name.last}
+              </Typography>
+              <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+                <Stack spacing={2} sx={{ flex: 1 }}>
+                  <TextField
+                    label="First Name"
+                    size="small"
+                    value={editedCustomer.name.first}
+                    onChange={(e) => handleUpdateField("name.first", e.target.value)}
+                  />
+                  <TextField
+                    label="Last Name"
+                    size="small"
+                    value={editedCustomer.name.last}
+                    onChange={(e) => handleUpdateField("name.last", e.target.value)}
+                  />
+                  <TextField
+                    label="Email"
+                    size="small"
+                    value={editedCustomer.email}
+                    onChange={(e) => handleUpdateField("email", e.target.value)}
+                  />
+                  <FormControl size="small">
+                    <InputLabel>Title</InputLabel>
+                    <Select
+                      value={editedCustomer.name.title}
+                      label="Title"
+                      onChange={(e) => handleUpdateField("name.title", e.target.value)}
+                    >
+                      <MenuItem value="Mr">Mr</MenuItem>
+                      <MenuItem value="Ms">Ms</MenuItem>
+                      <MenuItem value="Mrs">Mrs</MenuItem>
+                      <MenuItem value="Dr">Dr</MenuItem>
+                    </Select>
+                  </FormControl>
+                </Stack>
+                <Stack spacing={2} sx={{ flex: 1 }}>
+                  <TextField
+                    label="Phone"
+                    size="small"
+                    value={editedCustomer.phone}
+                    onChange={(e) => handleUpdateField("phone", e.target.value)}
+                  />
+                  <TextField
+                    label="City"
+                    size="small"
+                    value={editedCustomer.location.city}
+                    onChange={(e) => handleUpdateField("location.city", e.target.value)}
+                  />
+                  <TextField
+                    label="Country"
+                    size="small"
+                    value={editedCustomer.location.country}
+                    onChange={(e) => handleUpdateField("location.country", e.target.value)}
+                  />
+                  <FormControl size="small">
+                    <InputLabel>Status</InputLabel>
+                    <Select defaultValue="active" label="Status">
+                      <MenuItem value="active">Active</MenuItem>
+                      <MenuItem value="inactive">Inactive</MenuItem>
+                    </Select>
+                  </FormControl>
+                </Stack>
+              </Stack>
+              <Button variant="contained" onClick={handleSaveCustomer}>
+                Save Changes
+              </Button>
+            </Box>
+          </Stack>
+        </Paper>
+      )}
+
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <TextField
+          placeholder="Search for names"
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          sx={{ flex: 1 }}
+          size="small"
+        />
+        <FormControl size="small" sx={{ minWidth: 150 }}>
+          <InputLabel>Filter</InputLabel>
+          <Select defaultValue="all" label="Filter">
+            <MenuItem value="all">All</MenuItem>
+            <MenuItem value="active">Active</MenuItem>
+            <MenuItem value="inactive">Inactive</MenuItem>
+          </Select>
+        </FormControl>
+        <FormControl size="small" sx={{ minWidth: 150 }}>
+          <InputLabel>Filter</InputLabel>
+          <Select defaultValue="all" label="Filter">
+            <MenuItem value="all">All</MenuItem>
+            <MenuItem value="recent">Recent</MenuItem>
+          </Select>
+        </FormControl>
+        <Button variant="contained">Search</Button>
+      </Stack>
+
+      {loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <TableContainer component={Paper}>
+          <Table>
+            <TableHead sx={{ bgcolor: "action.hover" }}>
+              <TableRow>
+                <TableCell padding="checkbox">
+                  <Checkbox />
+                </TableCell>
+                <TableCell>
+                  <TableSortLabel
+                    active={sortField === "name"}
+                    direction={sortField === "name" ? sortDirection : "asc"}
+                    onClick={() => handleSort("name")}
+                  >
+                    Name
+                  </TableSortLabel>
+                </TableCell>
+                <TableCell>
+                  <TableSortLabel
+                    active={sortField === "email"}
+                    direction={sortField === "email" ? sortDirection : "asc"}
+                    onClick={() => handleSort("email")}
+                  >
+                    Email
+                  </TableSortLabel>
+                </TableCell>
+                <TableCell>
+                  <TableSortLabel
+                    active={sortField === "location"}
+                    direction={sortField === "location" ? sortDirection : "asc"}
+                    onClick={() => handleSort("location")}
+                  >
+                    Location
+                  </TableSortLabel>
+                </TableCell>
+                <TableCell>
+                  <TableSortLabel
+                    active={sortField === "phone"}
+                    direction={sortField === "phone" ? sortDirection : "asc"}
+                    onClick={() => handleSort("phone")}
+                  >
+                    Phone
+                  </TableSortLabel>
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {customers.map((customer) => (
+                <TableRow
+                  key={customer.login.uuid}
+                  hover
+                  onClick={() => handleRowClick(customer)}
+                  sx={{ cursor: "pointer" }}
+                  selected={selectedCustomer?.login.uuid === customer.login.uuid}
+                >
+                  <TableCell padding="checkbox">
+                    <Checkbox />
+                  </TableCell>
+                  <TableCell>
+                    {customer.name.first} {customer.name.last}
+                  </TableCell>
+                  <TableCell>{customer.email}</TableCell>
+                  <TableCell>
+                    {customer.location.city}, {customer.location.country}
+                  </TableCell>
+                  <TableCell>{customer.phone}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      <Dialog open={openDialog} onClose={() => setOpenDialog(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Create New Customer</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <TextField
+              label="Email"
+              type="email"
+              fullWidth
+              required
+              value={newCustomer.email}
+              onChange={(e) => setNewCustomer({ ...newCustomer, email: e.target.value })}
+            />
+            <TextField
+              label="Username"
+              fullWidth
+              required
+              value={newCustomer.username}
+              onChange={(e) => setNewCustomer({ ...newCustomer, username: e.target.value })}
+            />
+            <Stack direction="row" spacing={2}>
+              <TextField
+                label="First Name"
+                fullWidth
+                required
+                value={newCustomer.firstName}
+                onChange={(e) => setNewCustomer({ ...newCustomer, firstName: e.target.value })}
+              />
+              <TextField
+                label="Last Name"
+                fullWidth
+                required
+                value={newCustomer.lastName}
+                onChange={(e) => setNewCustomer({ ...newCustomer, lastName: e.target.value })}
+              />
+            </Stack>
+            <Stack direction="row" spacing={2}>
+              <TextField
+                label="City"
+                fullWidth
+                value={newCustomer.city}
+                onChange={(e) => setNewCustomer({ ...newCustomer, city: e.target.value })}
+              />
+              <TextField
+                label="Country"
+                fullWidth
+                value={newCustomer.country}
+                onChange={(e) => setNewCustomer({ ...newCustomer, country: e.target.value })}
+              />
+            </Stack>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenDialog(false)}>Cancel</Button>
+          <Button
+            onClick={handleCreateCustomer}
+            variant="contained"
+            disabled={creating || !newCustomer.email || !newCustomer.username || !newCustomer.firstName || !newCustomer.lastName}
+          >
+            {creating ? "Creating..." : "Create"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}


### PR DESCRIPTION
### Purpose

This change introduces three prototypes for a customer management interface to explore different UI/UX approaches for managing customer data. All versions include the ability to search, create new customers, and fetch data from the Users API.

- **V1:** Displays customers in a grid of cards.
- **V2:** Modeled after the HubSpot contacts page, featuring saved filter views and a data table.
- **V3:** Based on a Figma wireframe, selecting a customer from a table displays their editable profile details above it.

### Code changes

- **New Pages:**
    - `CustomersV1.tsx`: Implements the customer management interface using a responsive grid of cards.
    - `CustomersV2.tsx`: Implements the HubSpot-style interface with a data table, search, and filter views.
    - `CustomersV3.tsx`: Implements the Figma-based design with a customer table and an editable profile section that appears on selection.
- **Routing & Navigation:**
    - Added routes in `CrmDashboard.tsx` for `/customers-v1`, `/customers-v2`, and `/customers-v3`.
    - Updated `CrmMenuContent.tsx` to include links to the three new pages in the sidebar menu.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f325fd1fccb44259b91210edc9d123e5/zenith-hub)

👀 [Preview Link](https://f325fd1fccb44259b91210edc9d123e5-zenith-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f325fd1fccb44259b91210edc9d123e5</projectId>-->
<!--<branchName>zenith-hub</branchName>-->