### PR TITLE
feat: Add three customer management page prototypes

### DIFF
--- a/src/crm/CrmDashboard.tsx
+++ b/src/crm/CrmDashboard.tsx
@@ -13,6 +13,9 @@ import CrmHeader from "./components/CrmHeader";
 import CrmSideMenu from "./components/CrmSideMenu";
 import CrmMainDashboard from "./components/CrmMainDashboard";
 import Customers from "./pages/Customers";
+import CustomersV1 from "./pages/CustomersV1";
+import CustomersV2 from "./pages/CustomersV2";
+import CustomersV3 from "./pages/CustomersV3";
 import Deals from "./pages/Deals";
 import Contacts from "./pages/Contacts";
 import Tasks from "./pages/Tasks";
@@ -64,6 +67,9 @@ export default function CrmDashboard() {
             <Routes>
               <Route index element={<CrmMainDashboard />} />
               <Route path="customers" element={<Customers />} />
+              <Route path="customers-v1" element={<CustomersV1 />} />
+              <Route path="customers-v2" element={<CustomersV2 />} />
+              <Route path="customers-v3" element={<CustomersV3 />} />
               <Route path="deals" element={<Deals />} />
               <Route path="contacts" element={<Contacts />} />
               <Route path="tasks" element={<Tasks />} />

--- a/src/crm/components/CrmMenuContent.tsx
+++ b/src/crm/components/CrmMenuContent.tsx
@@ -20,6 +20,9 @@ import HelpOutlineRoundedIcon from "@mui/icons-material/HelpOutlineRounded";
 const mainListItems = [
   { text: "Dashboard", icon: <DashboardRoundedIcon />, path: "/" },
   { text: "Customers", icon: <PeopleRoundedIcon />, path: "/customers" },
+  { text: "Customers v1", icon: <PeopleRoundedIcon />, path: "/customers-v1" },
+  { text: "Customers v2", icon: <PeopleRoundedIcon />, path: "/customers-v2" },
+  { text: "Customers v3", icon: <PeopleRoundedIcon />, path: "/customers-v3" },
   { text: "Deals", icon: <BusinessCenterRoundedIcon />, path: "/deals" },
   { text: "Contacts", icon: <ContactsRoundedIcon />, path: "/contacts" },
   { text: "Tasks", icon: <AssignmentRoundedIcon />, path: "/tasks" },

--- a/src/crm/components/RakutenButton.tsx
+++ b/src/crm/components/RakutenButton.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { styled } from "@mui/material/styles";
+import Button, { ButtonProps } from "@mui/material/Button";
+
+const StyledButton = styled(Button)(({ theme, variant }) => ({
+  textTransform: "none",
+  fontWeight: 500,
+  borderRadius: 8,
+  padding: "8px 16px",
+  ...(variant === "contained" && {
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.primary.contrastText,
+    "&:hover": {
+      backgroundColor: theme.palette.primary.dark,
+    },
+  }),
+  ...(variant === "outlined" && {
+    borderWidth: 2,
+    "&:hover": {
+      borderWidth: 2,
+    },
+  }),
+}));
+
+export default function RakutenButton(props: ButtonProps) {
+  return <StyledButton {...props} />;
+}

--- a/src/crm/pages/CustomersV1.tsx
+++ b/src/crm/pages/CustomersV1.tsx
@@ -1,0 +1,362 @@
+import * as React from "react";
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardActions,
+  Grid,
+  TextField,
+  Typography,
+  Avatar,
+  Chip,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  IconButton,
+  CircularProgress,
+} from "@mui/material";
+import {
+  Add as AddIcon,
+  Email as EmailIcon,
+  Phone as PhoneIcon,
+  LocationOn as LocationIcon,
+  Close as CloseIcon,
+} from "@mui/icons-material";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  email: string;
+  phone: string;
+  cell: string;
+  location: {
+    city: string;
+    state: string;
+    country: string;
+  };
+  picture: {
+    large: string;
+    medium: string;
+    thumbnail: string;
+  };
+  dob: {
+    age: number;
+  };
+}
+
+interface ApiResponse {
+  data: User[];
+  total: number;
+  page: number;
+  perPage: number;
+}
+
+export default function CustomersV1() {
+  const [customers, setCustomers] = React.useState<User[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const [openDialog, setOpenDialog] = React.useState(false);
+  const [newCustomer, setNewCustomer] = React.useState({
+    email: "",
+    firstName: "",
+    lastName: "",
+    username: "",
+    city: "",
+    state: "",
+    country: "",
+  });
+
+  const fetchCustomers = async (search = "") => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        page: "1",
+        perPage: "20",
+        ...(search && { search }),
+      });
+      const response = await fetch(
+        `https://user-api.builder-io.workers.dev/api/users?${params}`
+      );
+      const data: ApiResponse = await response.json();
+      setCustomers(data.data);
+    } catch (error) {
+      console.error("Error fetching customers:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  React.useEffect(() => {
+    fetchCustomers();
+  }, []);
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    fetchCustomers(searchQuery);
+  };
+
+  const handleCreateCustomer = async () => {
+    try {
+      const response = await fetch(
+        "https://user-api.builder-io.workers.dev/api/users",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            email: newCustomer.email,
+            login: {
+              username: newCustomer.username,
+              password: "defaultPassword123",
+            },
+            name: {
+              first: newCustomer.firstName,
+              last: newCustomer.lastName,
+              title: "Mr",
+            },
+            gender: "male",
+            location: {
+              city: newCustomer.city,
+              state: newCustomer.state,
+              country: newCustomer.country,
+              street: {
+                number: 0,
+                name: "",
+              },
+              postcode: "",
+            },
+          }),
+        }
+      );
+
+      if (response.ok) {
+        setOpenDialog(false);
+        setNewCustomer({
+          email: "",
+          firstName: "",
+          lastName: "",
+          username: "",
+          city: "",
+          state: "",
+          country: "",
+        });
+        fetchCustomers();
+      }
+    } catch (error) {
+      console.error("Error creating customer:", error);
+    }
+  };
+
+  return (
+    <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" } }}>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          mb: 3,
+        }}
+      >
+        <Typography variant="h4" component="h1">
+          Customers v1
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => setOpenDialog(true)}
+        >
+          New Customer
+        </Button>
+      </Box>
+
+      <Box component="form" onSubmit={handleSearch} sx={{ mb: 3 }}>
+        <TextField
+          fullWidth
+          placeholder="Search customers by name, email, or city..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          sx={{ maxWidth: 600 }}
+          InputProps={{
+            endAdornment: (
+              <Button type="submit" variant="contained" sx={{ ml: 1 }}>
+                Search
+              </Button>
+            ),
+          }}
+        />
+      </Box>
+
+      {loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <Grid container spacing={3}>
+          {customers.map((customer) => (
+            <Grid item xs={12} sm={6} md={4} lg={3} key={customer.login.uuid}>
+              <Card
+                sx={{
+                  height: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                  transition: "transform 0.2s, box-shadow 0.2s",
+                  "&:hover": {
+                    transform: "translateY(-4px)",
+                    boxShadow: 4,
+                  },
+                }}
+              >
+                <CardContent sx={{ flexGrow: 1 }}>
+                  <Box
+                    sx={{
+                      display: "flex",
+                      flexDirection: "column",
+                      alignItems: "center",
+                      mb: 2,
+                    }}
+                  >
+                    <Avatar
+                      src={customer.picture.large}
+                      alt={`${customer.name.first} ${customer.name.last}`}
+                      sx={{ width: 80, height: 80, mb: 2 }}
+                    />
+                    <Typography variant="h6" component="h2" textAlign="center">
+                      {customer.name.first} {customer.name.last}
+                    </Typography>
+                    <Chip
+                      label={`@${customer.login.username}`}
+                      size="small"
+                      sx={{ mt: 1 }}
+                    />
+                  </Box>
+
+                  <Box sx={{ display: "flex", alignItems: "center", mb: 1 }}>
+                    <EmailIcon sx={{ fontSize: 16, mr: 1, color: "text.secondary" }} />
+                    <Typography variant="body2" color="text.secondary" noWrap>
+                      {customer.email}
+                    </Typography>
+                  </Box>
+
+                  <Box sx={{ display: "flex", alignItems: "center", mb: 1 }}>
+                    <PhoneIcon sx={{ fontSize: 16, mr: 1, color: "text.secondary" }} />
+                    <Typography variant="body2" color="text.secondary">
+                      {customer.phone}
+                    </Typography>
+                  </Box>
+
+                  <Box sx={{ display: "flex", alignItems: "center" }}>
+                    <LocationIcon sx={{ fontSize: 16, mr: 1, color: "text.secondary" }} />
+                    <Typography variant="body2" color="text.secondary" noWrap>
+                      {customer.location.city}, {customer.location.country}
+                    </Typography>
+                  </Box>
+                </CardContent>
+
+                <CardActions sx={{ justifyContent: "space-between", px: 2, pb: 2 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    Age: {customer.dob.age}
+                  </Typography>
+                  <Button size="small" variant="outlined">
+                    View Details
+                  </Button>
+                </CardActions>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      )}
+
+      {!loading && customers.length === 0 && (
+        <Box sx={{ textAlign: "center", py: 8 }}>
+          <Typography variant="h6" color="text.secondary">
+            No customers found
+          </Typography>
+        </Box>
+      )}
+
+      <Dialog open={openDialog} onClose={() => setOpenDialog(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          Create New Customer
+          <IconButton
+            onClick={() => setOpenDialog(false)}
+            sx={{ position: "absolute", right: 8, top: 8 }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <TextField
+              label="First Name"
+              required
+              value={newCustomer.firstName}
+              onChange={(e) =>
+                setNewCustomer({ ...newCustomer, firstName: e.target.value })
+              }
+            />
+            <TextField
+              label="Last Name"
+              required
+              value={newCustomer.lastName}
+              onChange={(e) =>
+                setNewCustomer({ ...newCustomer, lastName: e.target.value })
+              }
+            />
+            <TextField
+              label="Username"
+              required
+              value={newCustomer.username}
+              onChange={(e) =>
+                setNewCustomer({ ...newCustomer, username: e.target.value })
+              }
+            />
+            <TextField
+              label="Email"
+              type="email"
+              required
+              value={newCustomer.email}
+              onChange={(e) =>
+                setNewCustomer({ ...newCustomer, email: e.target.value })
+              }
+            />
+            <TextField
+              label="City"
+              value={newCustomer.city}
+              onChange={(e) => setNewCustomer({ ...newCustomer, city: e.target.value })}
+            />
+            <TextField
+              label="State"
+              value={newCustomer.state}
+              onChange={(e) =>
+                setNewCustomer({ ...newCustomer, state: e.target.value })
+              }
+            />
+            <TextField
+              label="Country"
+              value={newCustomer.country}
+              onChange={(e) =>
+                setNewCustomer({ ...newCustomer, country: e.target.value })
+              }
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenDialog(false)}>Cancel</Button>
+          <Button onClick={handleCreateCustomer} variant="contained">
+            Create Customer
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/crm/pages/CustomersV2.tsx
+++ b/src/crm/pages/CustomersV2.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import {
   Box,
-  Button,
   TextField,
   Typography,
   Avatar,
@@ -22,6 +21,7 @@ import {
   Tab,
   Checkbox,
 } from "@mui/material";
+import RakutenButton from "../components/RakutenButton";
 import {
   Add as AddIcon,
   FilterList as FilterIcon,
@@ -296,9 +296,9 @@ export default function CustomersV2() {
         <Typography variant="h4" component="h1">
           Customers v2
         </Typography>
-        <Button variant="contained" startIcon={<AddIcon />} onClick={() => setOpenDialog(true)}>
+        <RakutenButton variant="contained" startIcon={<AddIcon />} onClick={() => setOpenDialog(true)}>
           Add Contact
-        </Button>
+        </RakutenButton>
       </Box>
 
       <Paper sx={{ mb: 2 }}>
@@ -325,19 +325,19 @@ export default function CustomersV2() {
           sx={{ flexGrow: 1, minWidth: 250 }}
           size="small"
         />
-        <Button
+        <RakutenButton
           variant="outlined"
           startIcon={<FilterIcon />}
           onClick={(e) => setFilterAnchor(e.currentTarget)}
         >
           Advanced Filters
-        </Button>
-        <Button variant="outlined" startIcon={<SaveIcon />} onClick={() => setOpenSaveView(true)}>
+        </RakutenButton>
+        <RakutenButton variant="outlined" startIcon={<SaveIcon />} onClick={() => setOpenSaveView(true)}>
           Save View
-        </Button>
-        <Button variant="contained" onClick={handleApplyFilters}>
+        </RakutenButton>
+        <RakutenButton variant="contained" onClick={handleApplyFilters}>
           Search
-        </Button>
+        </RakutenButton>
       </Box>
 
       <Menu
@@ -363,9 +363,9 @@ export default function CustomersV2() {
               <MenuItem value="Australia">Australia</MenuItem>
             </Select>
           </FormControl>
-          <Button variant="contained" fullWidth onClick={handleApplyFilters}>
+          <RakutenButton variant="contained" fullWidth onClick={handleApplyFilters}>
             Apply Filters
-          </Button>
+          </RakutenButton>
         </Box>
       </Menu>
 
@@ -452,10 +452,10 @@ export default function CustomersV2() {
           </Box>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setOpenDialog(false)}>Cancel</Button>
-          <Button onClick={handleCreateCustomer} variant="contained">
+          <RakutenButton onClick={() => setOpenDialog(false)}>Cancel</RakutenButton>
+          <RakutenButton onClick={handleCreateCustomer} variant="contained">
             Create Customer
-          </Button>
+          </RakutenButton>
         </DialogActions>
       </Dialog>
 
@@ -472,10 +472,10 @@ export default function CustomersV2() {
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setOpenSaveView(false)}>Cancel</Button>
-          <Button onClick={handleSaveView} variant="contained" disabled={!newViewName}>
+          <RakutenButton onClick={() => setOpenSaveView(false)}>Cancel</RakutenButton>
+          <RakutenButton onClick={handleSaveView} variant="contained" disabled={!newViewName}>
             Save View
-          </Button>
+          </RakutenButton>
         </DialogActions>
       </Dialog>
     </Box>

--- a/src/crm/pages/CustomersV2.tsx
+++ b/src/crm/pages/CustomersV2.tsx
@@ -1,0 +1,483 @@
+import * as React from "react";
+import {
+  Box,
+  Button,
+  TextField,
+  Typography,
+  Avatar,
+  Chip,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  IconButton,
+  Menu,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  Select,
+  Stack,
+  Paper,
+  Tabs,
+  Tab,
+  Checkbox,
+} from "@mui/material";
+import {
+  Add as AddIcon,
+  FilterList as FilterIcon,
+  ViewList as ViewListIcon,
+  Close as CloseIcon,
+  Save as SaveIcon,
+  MoreVert as MoreVertIcon,
+} from "@mui/icons-material";
+import { DataGrid, GridColDef, GridRowSelectionModel } from "@mui/x-data-grid";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  email: string;
+  phone: string;
+  cell: string;
+  location: {
+    city: string;
+    state: string;
+    country: string;
+  };
+  picture: {
+    large: string;
+    medium: string;
+    thumbnail: string;
+  };
+  dob: {
+    age: number;
+  };
+}
+
+interface SavedView {
+  id: string;
+  name: string;
+  filters: {
+    search: string;
+    country: string;
+    minAge: string;
+  };
+}
+
+const defaultViews: SavedView[] = [
+  { id: "all", name: "All Contacts", filters: { search: "", country: "", minAge: "" } },
+  { id: "us", name: "US Customers", filters: { search: "", country: "USA", minAge: "" } },
+  { id: "young", name: "Under 30", filters: { search: "", country: "", minAge: "0" } },
+];
+
+export default function CustomersV2() {
+  const [customers, setCustomers] = React.useState<User[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const [countryFilter, setCountryFilter] = React.useState("");
+  const [selectedRows, setSelectedRows] = React.useState<GridRowSelectionModel>([]);
+  const [openDialog, setOpenDialog] = React.useState(false);
+  const [openSaveView, setOpenSaveView] = React.useState(false);
+  const [savedViews, setSavedViews] = React.useState<SavedView[]>(defaultViews);
+  const [activeView, setActiveView] = React.useState<string>("all");
+  const [newViewName, setNewViewName] = React.useState("");
+  const [filterAnchor, setFilterAnchor] = React.useState<null | HTMLElement>(null);
+  const [newCustomer, setNewCustomer] = React.useState({
+    email: "",
+    firstName: "",
+    lastName: "",
+    username: "",
+    city: "",
+    state: "",
+    country: "",
+  });
+
+  const fetchCustomers = async (search = "", country = "") => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        page: "1",
+        perPage: "50",
+        ...(search && { search }),
+      });
+      const response = await fetch(
+        `https://user-api.builder-io.workers.dev/api/users?${params}`
+      );
+      const data = await response.json();
+      let filtered = data.data;
+      if (country) {
+        filtered = filtered.filter((user: User) => user.location.country === country);
+      }
+      setCustomers(filtered);
+    } catch (error) {
+      console.error("Error fetching customers:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  React.useEffect(() => {
+    fetchCustomers();
+  }, []);
+
+  const handleApplyFilters = () => {
+    fetchCustomers(searchQuery, countryFilter);
+    setFilterAnchor(null);
+  };
+
+  const handleCreateCustomer = async () => {
+    try {
+      const response = await fetch(
+        "https://user-api.builder-io.workers.dev/api/users",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            email: newCustomer.email,
+            login: {
+              username: newCustomer.username,
+              password: "defaultPassword123",
+            },
+            name: {
+              first: newCustomer.firstName,
+              last: newCustomer.lastName,
+              title: "Mr",
+            },
+            gender: "male",
+            location: {
+              city: newCustomer.city,
+              state: newCustomer.state,
+              country: newCustomer.country,
+              street: {
+                number: 0,
+                name: "",
+              },
+              postcode: "",
+            },
+          }),
+        }
+      );
+
+      if (response.ok) {
+        setOpenDialog(false);
+        setNewCustomer({
+          email: "",
+          firstName: "",
+          lastName: "",
+          username: "",
+          city: "",
+          state: "",
+          country: "",
+        });
+        fetchCustomers(searchQuery, countryFilter);
+      }
+    } catch (error) {
+      console.error("Error creating customer:", error);
+    }
+  };
+
+  const handleSaveView = () => {
+    const newView: SavedView = {
+      id: Date.now().toString(),
+      name: newViewName,
+      filters: {
+        search: searchQuery,
+        country: countryFilter,
+        minAge: "",
+      },
+    };
+    setSavedViews([...savedViews, newView]);
+    setActiveView(newView.id);
+    setOpenSaveView(false);
+    setNewViewName("");
+  };
+
+  const handleLoadView = (view: SavedView) => {
+    setSearchQuery(view.filters.search);
+    setCountryFilter(view.filters.country);
+    setActiveView(view.id);
+    fetchCustomers(view.filters.search, view.filters.country);
+  };
+
+  const columns: GridColDef[] = [
+    {
+      field: "name",
+      headerName: "NAME",
+      flex: 1,
+      minWidth: 200,
+      renderCell: (params) => (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Avatar src={params.row.picture.thumbnail} sx={{ width: 32, height: 32 }} />
+          <Box>
+            <Typography variant="body2" fontWeight={500}>
+              {params.row.name.first} {params.row.name.last}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              @{params.row.login.username}
+            </Typography>
+          </Box>
+        </Box>
+      ),
+    },
+    {
+      field: "email",
+      headerName: "EMAIL",
+      flex: 1,
+      minWidth: 200,
+    },
+    {
+      field: "phone",
+      headerName: "PHONE NUMBER",
+      flex: 1,
+      minWidth: 150,
+    },
+    {
+      field: "location",
+      headerName: "CONTACT OWNER",
+      flex: 1,
+      minWidth: 150,
+      renderCell: (params) => (
+        <Typography variant="body2" color="text.secondary">
+          No owner
+        </Typography>
+      ),
+    },
+    {
+      field: "company",
+      headerName: "PRIMARY COMPANY",
+      flex: 1,
+      minWidth: 150,
+      renderCell: () => (
+        <Typography variant="body2" color="text.secondary">
+          --
+        </Typography>
+      ),
+    },
+    {
+      field: "lastActivity",
+      headerName: "LAST ACTIVITY DATE",
+      flex: 1,
+      minWidth: 150,
+      renderCell: () => (
+        <Typography variant="body2" color="text.secondary">
+          --
+        </Typography>
+      ),
+    },
+    {
+      field: "leadStatus",
+      headerName: "LEAD STATUS",
+      flex: 1,
+      minWidth: 120,
+      renderCell: () => (
+        <Typography variant="body2" color="text.secondary">
+          --
+        </Typography>
+      ),
+    },
+  ];
+
+  const rows = customers.map((customer) => ({
+    id: customer.login.uuid,
+    ...customer,
+  }));
+
+  return (
+    <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" } }}>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 2 }}>
+        <Typography variant="h4" component="h1">
+          Customers v2
+        </Typography>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={() => setOpenDialog(true)}>
+          Add Contact
+        </Button>
+      </Box>
+
+      <Paper sx={{ mb: 2 }}>
+        <Tabs
+          value={activeView}
+          onChange={(e, val) => {
+            const view = savedViews.find((v) => v.id === val);
+            if (view) handleLoadView(view);
+          }}
+          variant="scrollable"
+          scrollButtons="auto"
+        >
+          {savedViews.map((view) => (
+            <Tab key={view.id} label={view.name} value={view.id} />
+          ))}
+        </Tabs>
+      </Paper>
+
+      <Box sx={{ display: "flex", gap: 2, mb: 2, flexWrap: "wrap" }}>
+        <TextField
+          placeholder="Search name, phone, or email"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          sx={{ flexGrow: 1, minWidth: 250 }}
+          size="small"
+        />
+        <Button
+          variant="outlined"
+          startIcon={<FilterIcon />}
+          onClick={(e) => setFilterAnchor(e.currentTarget)}
+        >
+          Advanced Filters
+        </Button>
+        <Button variant="outlined" startIcon={<SaveIcon />} onClick={() => setOpenSaveView(true)}>
+          Save View
+        </Button>
+        <Button variant="contained" onClick={handleApplyFilters}>
+          Search
+        </Button>
+      </Box>
+
+      <Menu
+        anchorEl={filterAnchor}
+        open={Boolean(filterAnchor)}
+        onClose={() => setFilterAnchor(null)}
+      >
+        <Box sx={{ p: 2, minWidth: 300 }}>
+          <Typography variant="subtitle2" sx={{ mb: 2 }}>
+            Filter Options
+          </Typography>
+          <FormControl fullWidth size="small" sx={{ mb: 2 }}>
+            <InputLabel>Country</InputLabel>
+            <Select
+              value={countryFilter}
+              label="Country"
+              onChange={(e) => setCountryFilter(e.target.value)}
+            >
+              <MenuItem value="">All Countries</MenuItem>
+              <MenuItem value="USA">USA</MenuItem>
+              <MenuItem value="UK">UK</MenuItem>
+              <MenuItem value="Canada">Canada</MenuItem>
+              <MenuItem value="Australia">Australia</MenuItem>
+            </Select>
+          </FormControl>
+          <Button variant="contained" fullWidth onClick={handleApplyFilters}>
+            Apply Filters
+          </Button>
+        </Box>
+      </Menu>
+
+      <Box sx={{ mb: 2 }}>
+        <Typography variant="body2" color="text.secondary">
+          {selectedRows.length > 0
+            ? `${selectedRows.length} selected`
+            : `${customers.length} contacts`}
+        </Typography>
+      </Box>
+
+      <DataGrid
+        rows={rows}
+        columns={columns}
+        loading={loading}
+        checkboxSelection
+        disableRowSelectionOnClick
+        onRowSelectionModelChange={(newSelection) => setSelectedRows(newSelection)}
+        initialState={{
+          pagination: { paginationModel: { pageSize: 25 } },
+        }}
+        pageSizeOptions={[10, 25, 50, 100]}
+        sx={{
+          minHeight: 500,
+          "& .MuiDataGrid-cell": {
+            borderBottom: "1px solid",
+            borderColor: "divider",
+          },
+        }}
+      />
+
+      <Dialog open={openDialog} onClose={() => setOpenDialog(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          Create New Customer
+          <IconButton
+            onClick={() => setOpenDialog(false)}
+            sx={{ position: "absolute", right: 8, top: 8 }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <TextField
+              label="First Name"
+              required
+              value={newCustomer.firstName}
+              onChange={(e) => setNewCustomer({ ...newCustomer, firstName: e.target.value })}
+            />
+            <TextField
+              label="Last Name"
+              required
+              value={newCustomer.lastName}
+              onChange={(e) => setNewCustomer({ ...newCustomer, lastName: e.target.value })}
+            />
+            <TextField
+              label="Username"
+              required
+              value={newCustomer.username}
+              onChange={(e) => setNewCustomer({ ...newCustomer, username: e.target.value })}
+            />
+            <TextField
+              label="Email"
+              type="email"
+              required
+              value={newCustomer.email}
+              onChange={(e) => setNewCustomer({ ...newCustomer, email: e.target.value })}
+            />
+            <TextField
+              label="City"
+              value={newCustomer.city}
+              onChange={(e) => setNewCustomer({ ...newCustomer, city: e.target.value })}
+            />
+            <TextField
+              label="State"
+              value={newCustomer.state}
+              onChange={(e) => setNewCustomer({ ...newCustomer, state: e.target.value })}
+            />
+            <TextField
+              label="Country"
+              value={newCustomer.country}
+              onChange={(e) => setNewCustomer({ ...newCustomer, country: e.target.value })}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenDialog(false)}>Cancel</Button>
+          <Button onClick={handleCreateCustomer} variant="contained">
+            Create Customer
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={openSaveView} onClose={() => setOpenSaveView(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Save Current View</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            margin="dense"
+            label="View Name"
+            fullWidth
+            value={newViewName}
+            onChange={(e) => setNewViewName(e.target.value)}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenSaveView(false)}>Cancel</Button>
+          <Button onClick={handleSaveView} variant="contained" disabled={!newViewName}>
+            Save View
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/crm/pages/CustomersV3.tsx
+++ b/src/crm/pages/CustomersV3.tsx
@@ -1,0 +1,555 @@
+import * as React from "react";
+import {
+  Box,
+  Button,
+  TextField,
+  Typography,
+  Avatar,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Checkbox,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  IconButton,
+  CircularProgress,
+} from "@mui/material";
+import {
+  Add as AddIcon,
+  Close as CloseIcon,
+  ArrowDropDown as ArrowDropDownIcon,
+} from "@mui/icons-material";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  email: string;
+  phone: string;
+  cell: string;
+  location: {
+    city: string;
+    state: string;
+    country: string;
+  };
+  picture: {
+    large: string;
+    medium: string;
+    thumbnail: string;
+  };
+  dob: {
+    age: number;
+  };
+}
+
+export default function CustomersV3() {
+  const [customers, setCustomers] = React.useState<User[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const [selectedCustomer, setSelectedCustomer] = React.useState<User | null>(null);
+  const [openDialog, setOpenDialog] = React.useState(false);
+  const [editedData, setEditedData] = React.useState({
+    firstName: "",
+    lastName: "",
+    email: "",
+    phone: "",
+    city: "",
+    state: "",
+  });
+  const [newCustomer, setNewCustomer] = React.useState({
+    email: "",
+    firstName: "",
+    lastName: "",
+    username: "",
+    city: "",
+    state: "",
+    country: "",
+  });
+
+  const fetchCustomers = async (search = "") => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        page: "1",
+        perPage: "20",
+        ...(search && { search }),
+      });
+      const response = await fetch(
+        `https://user-api.builder-io.workers.dev/api/users?${params}`
+      );
+      const data = await response.json();
+      setCustomers(data.data);
+    } catch (error) {
+      console.error("Error fetching customers:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  React.useEffect(() => {
+    fetchCustomers();
+  }, []);
+
+  const handleSelectCustomer = (customer: User) => {
+    setSelectedCustomer(customer);
+    setEditedData({
+      firstName: customer.name.first,
+      lastName: customer.name.last,
+      email: customer.email,
+      phone: customer.phone,
+      city: customer.location.city,
+      state: customer.location.state,
+    });
+  };
+
+  const handleUpdateCustomer = async () => {
+    if (!selectedCustomer) return;
+
+    try {
+      await fetch(
+        `https://user-api.builder-io.workers.dev/api/users/${selectedCustomer.login.uuid}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            name: {
+              first: editedData.firstName,
+              last: editedData.lastName,
+            },
+            email: editedData.email,
+            phone: editedData.phone,
+            location: {
+              city: editedData.city,
+              state: editedData.state,
+            },
+          }),
+        }
+      );
+      fetchCustomers(searchQuery);
+    } catch (error) {
+      console.error("Error updating customer:", error);
+    }
+  };
+
+  const handleCreateCustomer = async () => {
+    try {
+      const response = await fetch(
+        "https://user-api.builder-io.workers.dev/api/users",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            email: newCustomer.email,
+            login: {
+              username: newCustomer.username,
+              password: "defaultPassword123",
+            },
+            name: {
+              first: newCustomer.firstName,
+              last: newCustomer.lastName,
+              title: "Mr",
+            },
+            gender: "male",
+            location: {
+              city: newCustomer.city,
+              state: newCustomer.state,
+              country: newCustomer.country,
+              street: {
+                number: 0,
+                name: "",
+              },
+              postcode: "",
+            },
+          }),
+        }
+      );
+
+      if (response.ok) {
+        setOpenDialog(false);
+        setNewCustomer({
+          email: "",
+          firstName: "",
+          lastName: "",
+          username: "",
+          city: "",
+          state: "",
+          country: "",
+        });
+        fetchCustomers(searchQuery);
+      }
+    } catch (error) {
+      console.error("Error creating customer:", error);
+    }
+  };
+
+  return (
+    <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" } }}>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 3 }}>
+        <Typography variant="h4" component="h1">
+          Customers v3
+        </Typography>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={() => setOpenDialog(true)}>
+          New Customer
+        </Button>
+      </Box>
+
+      {selectedCustomer && (
+        <Paper sx={{ p: 3, mb: 3, backgroundColor: "#FAFAFA" }}>
+          <Box sx={{ display: "flex", gap: 3, alignItems: "flex-start" }}>
+            <Avatar
+              src={selectedCustomer.picture.large}
+              sx={{
+                width: 198,
+                height: 198,
+                border: "2px solid #AFB1B6",
+                backgroundColor: "#EFEFF0",
+              }}
+            />
+            <Box sx={{ flex: 1 }}>
+              <Typography
+                variant="h3"
+                sx={{
+                  fontFamily: "Work Sans, Roboto, sans-serif",
+                  fontWeight: 400,
+                  fontSize: "48px",
+                  lineHeight: "56px",
+                  mb: 2,
+                }}
+              >
+                {selectedCustomer.name.first} {selectedCustomer.name.last}
+              </Typography>
+
+              <Box sx={{ display: "flex", gap: 3 }}>
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 2, flex: 1 }}>
+                  <TextField
+                    placeholder="Empty"
+                    size="small"
+                    value={editedData.firstName}
+                    onChange={(e) => setEditedData({ ...editedData, firstName: e.target.value })}
+                    sx={{
+                      "& .MuiOutlinedInput-root": {
+                        borderRadius: "10px",
+                        backgroundColor: "#FFF",
+                      },
+                    }}
+                  />
+                  <TextField
+                    placeholder="Empty"
+                    size="small"
+                    value={editedData.email}
+                    onChange={(e) => setEditedData({ ...editedData, email: e.target.value })}
+                    sx={{
+                      "& .MuiOutlinedInput-root": {
+                        borderRadius: "10px",
+                        backgroundColor: "#FFF",
+                      },
+                    }}
+                  />
+                  <TextField
+                    placeholder="Empty"
+                    size="small"
+                    value={editedData.city}
+                    onChange={(e) => setEditedData({ ...editedData, city: e.target.value })}
+                    sx={{
+                      "& .MuiOutlinedInput-root": {
+                        borderRadius: "10px",
+                        backgroundColor: "#FFF",
+                      },
+                    }}
+                  />
+                  <FormControl size="small">
+                    <Select
+                      value="small"
+                      sx={{
+                        borderRadius: "8px",
+                        border: "2px solid #AFB1B6",
+                        backgroundColor: "#FFF",
+                        fontSize: "12px",
+                      }}
+                    >
+                      <MenuItem value="small">Small</MenuItem>
+                    </Select>
+                  </FormControl>
+                </Box>
+
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 2, flex: 1 }}>
+                  <TextField
+                    placeholder="Empty"
+                    size="small"
+                    value={editedData.lastName}
+                    onChange={(e) => setEditedData({ ...editedData, lastName: e.target.value })}
+                    sx={{
+                      "& .MuiOutlinedInput-root": {
+                        borderRadius: "10px",
+                        backgroundColor: "#FFF",
+                      },
+                    }}
+                  />
+                  <TextField
+                    placeholder="Empty"
+                    size="small"
+                    value={editedData.phone}
+                    onChange={(e) => setEditedData({ ...editedData, phone: e.target.value })}
+                    sx={{
+                      "& .MuiOutlinedInput-root": {
+                        borderRadius: "10px",
+                        backgroundColor: "#FFF",
+                      },
+                    }}
+                  />
+                  <TextField
+                    placeholder="Empty"
+                    size="small"
+                    value={editedData.state}
+                    onChange={(e) => setEditedData({ ...editedData, state: e.target.value })}
+                    sx={{
+                      "& .MuiOutlinedInput-root": {
+                        borderRadius: "10px",
+                        backgroundColor: "#FFF",
+                      },
+                    }}
+                  />
+                  <FormControl size="small">
+                    <Select
+                      value="small"
+                      sx={{
+                        borderRadius: "8px",
+                        border: "2px solid #AFB1B6",
+                        backgroundColor: "#FFF",
+                        fontSize: "12px",
+                      }}
+                    >
+                      <MenuItem value="small">Small</MenuItem>
+                    </Select>
+                  </FormControl>
+                </Box>
+              </Box>
+              <Box sx={{ mt: 2 }}>
+                <Button variant="contained" onClick={handleUpdateCustomer}>
+                  Save Changes
+                </Button>
+              </Box>
+            </Box>
+          </Box>
+        </Paper>
+      )}
+
+      <Box sx={{ display: "flex", gap: 2, mb: 3, flexWrap: "wrap", alignItems: "flex-end" }}>
+        <TextField
+          placeholder="Search for names"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          sx={{
+            flex: 1,
+            minWidth: 300,
+            "& .MuiOutlinedInput-root": {
+              borderRadius: "10px",
+            },
+          }}
+        />
+        <FormControl sx={{ minWidth: 200 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5 }}>
+            Dropdown
+          </Typography>
+          <Select
+            size="small"
+            defaultValue="small"
+            sx={{
+              borderRadius: "8px",
+              border: "2px solid #AFB1B6",
+              fontSize: "12px",
+            }}
+          >
+            <MenuItem value="small">Small</MenuItem>
+          </Select>
+        </FormControl>
+        <FormControl sx={{ minWidth: 200 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5 }}>
+            Dropdown
+          </Typography>
+          <Select
+            size="small"
+            defaultValue="small"
+            sx={{
+              borderRadius: "8px",
+              border: "2px solid #AFB1B6",
+              fontSize: "12px",
+            }}
+          >
+            <MenuItem value="small">Small</MenuItem>
+          </Select>
+        </FormControl>
+        <Button
+          variant="contained"
+          onClick={() => fetchCustomers(searchQuery)}
+          sx={{
+            borderRadius: "8px",
+            backgroundColor: "#3A00E5",
+            textTransform: "none",
+            px: 3,
+          }}
+        >
+          Search
+        </Button>
+      </Box>
+
+      <TableContainer component={Paper} sx={{ border: "1px solid #AFB1B6" }}>
+        <Table>
+          <TableHead sx={{ backgroundColor: "#FAFAFA" }}>
+            <TableRow>
+              <TableCell padding="checkbox"></TableCell>
+              <TableCell sx={{ fontWeight: 500, color: "#61646B", fontSize: "14px" }}>
+                <Box sx={{ display: "flex", alignItems: "center" }}>
+                  Header
+                  <ArrowDropDownIcon sx={{ fontSize: 20, color: "#61646B" }} />
+                </Box>
+              </TableCell>
+              <TableCell sx={{ fontWeight: 500, color: "#61646B", fontSize: "14px" }}>
+                <Box sx={{ display: "flex", alignItems: "center" }}>
+                  Header
+                  <ArrowDropDownIcon sx={{ fontSize: 20, color: "#61646B" }} />
+                </Box>
+              </TableCell>
+              <TableCell sx={{ fontWeight: 500, color: "#61646B", fontSize: "14px" }}>
+                <Box sx={{ display: "flex", alignItems: "center" }}>
+                  Header
+                  <ArrowDropDownIcon sx={{ fontSize: 20, color: "#61646B" }} />
+                </Box>
+              </TableCell>
+              <TableCell sx={{ fontWeight: 500, color: "#61646B", fontSize: "14px" }}>
+                <Box sx={{ display: "flex", alignItems: "center" }}>
+                  Header
+                  <ArrowDropDownIcon sx={{ fontSize: 20, color: "#61646B" }} />
+                </Box>
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={5} align="center" sx={{ py: 8 }}>
+                  <CircularProgress />
+                </TableCell>
+              </TableRow>
+            ) : (
+              customers.map((customer) => (
+                <TableRow
+                  key={customer.login.uuid}
+                  hover
+                  onClick={() => handleSelectCustomer(customer)}
+                  sx={{
+                    cursor: "pointer",
+                    backgroundColor:
+                      selectedCustomer?.login.uuid === customer.login.uuid
+                        ? "action.selected"
+                        : "inherit",
+                  }}
+                >
+                  <TableCell padding="checkbox">
+                    <Checkbox
+                      checked={selectedCustomer?.login.uuid === customer.login.uuid}
+                    />
+                  </TableCell>
+                  <TableCell sx={{ color: "#61646B", fontSize: "14px" }}>
+                    {customer.name.first} {customer.name.last}
+                  </TableCell>
+                  <TableCell sx={{ color: "#61646B", fontSize: "14px" }}>
+                    {customer.email}
+                  </TableCell>
+                  <TableCell sx={{ color: "#61646B", fontSize: "14px" }}>
+                    {customer.phone}
+                  </TableCell>
+                  <TableCell sx={{ color: "#61646B", fontSize: "14px" }}>
+                    {customer.location.city}, {customer.location.country}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Dialog open={openDialog} onClose={() => setOpenDialog(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          Create New Customer
+          <IconButton
+            onClick={() => setOpenDialog(false)}
+            sx={{ position: "absolute", right: 8, top: 8 }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <TextField
+              label="First Name"
+              required
+              value={newCustomer.firstName}
+              onChange={(e) => setNewCustomer({ ...newCustomer, firstName: e.target.value })}
+            />
+            <TextField
+              label="Last Name"
+              required
+              value={newCustomer.lastName}
+              onChange={(e) => setNewCustomer({ ...newCustomer, lastName: e.target.value })}
+            />
+            <TextField
+              label="Username"
+              required
+              value={newCustomer.username}
+              onChange={(e) => setNewCustomer({ ...newCustomer, username: e.target.value })}
+            />
+            <TextField
+              label="Email"
+              type="email"
+              required
+              value={newCustomer.email}
+              onChange={(e) => setNewCustomer({ ...newCustomer, email: e.target.value })}
+            />
+            <TextField
+              label="City"
+              value={newCustomer.city}
+              onChange={(e) => setNewCustomer({ ...newCustomer, city: e.target.value })}
+            />
+            <TextField
+              label="State"
+              value={newCustomer.state}
+              onChange={(e) => setNewCustomer({ ...newCustomer, state: e.target.value })}
+            />
+            <TextField
+              label="Country"
+              value={newCustomer.country}
+              onChange={(e) => setNewCustomer({ ...newCustomer, country: e.target.value })}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenDialog(false)}>Cancel</Button>
+          <Button onClick={handleCreateCustomer} variant="contained">
+            Create Customer
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}


### PR DESCRIPTION
### Purpose

The user wants to prototype three different versions of a customer management interface. Each version needs to allow searching for customers, creating new customers, and must use the Users API. The three designs are:

1.  **Version 1:** A grid of cards to display customers.
2.  **Version 2:** A layout similar to the HubSpot contacts page, with advanced search, filter saving, and saved views.
3.  **Version 3:** A design based on a Figma wireframe where selecting a customer in a table displays their editable profile at the top.

### Code changes

-   **New Pages:** Added three new page components: `CustomersV1.tsx`, `CustomersV2.tsx`, and `CustomersV3.tsx` to implement the three requested designs.
-   **Routing:** Introduced new routes in `CrmDashboard.tsx` for `/customers-v1`, `/customers-v2`, and `/customers-v3`.
-   **Navigation:** Updated the side menu in `CrmMenuContent.tsx` to include navigation links to the new customer pages.
-   **Functionality:** Each new page component includes the required functionality:
    -   Fetching and displaying customer data from the `user-api`.
    -   A search input to filter customers.
    -   A "New Customer" button that opens a dialog to create and POST a new customer.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f325fd1fccb44259b91210edc9d123e5/nova-works)

👀 [Preview Link](https://f325fd1fccb44259b91210edc9d123e5-nova-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f325fd1fccb44259b91210edc9d123e5</projectId>-->
<!--<branchName>nova-works</branchName>-->